### PR TITLE
Cleaner UI for ownerships index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ Metrics/ModuleLength:
   Exclude:
     - lib/patterns.rb
     - app/models/concerns/rubygem_searchable.rb
+    - app/helpers/rubygems_helper.rb
 
 Metrics/PerceivedComplexity:
   Max: 10 # TODO: Lower to 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ Rails/OutputSafety:
   Exclude:
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/rubygems_helper.rb'
+    - 'test/integration/owner_test.rb'
 
 # Offense count: 38
 # Cop supports --auto-correct.

--- a/app/assets/stylesheets/modules/owners.css
+++ b/app/assets/stylesheets/modules/owners.css
@@ -28,6 +28,7 @@
     width: 100%;
     box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
     border-spacing: 0;
+    font-size: 16px;
 }
 @media screen and (max-width: 580px) {
     .owners__table {
@@ -67,9 +68,6 @@
         margin-bottom: 3px;
         content: attr(data-title);
         min-width: 98px;
-        font-size: 10px;
-        line-height: 10px;
-        font-weight: bold;
         text-transform: uppercase;
         color: #969696;
         display: block;
@@ -126,7 +124,7 @@
 }
 
 .add_owner__field {
-    max-width: 160px;
+    max-width: 320px;
 }
 /* Container for flex box */
 .row {
@@ -137,6 +135,12 @@
 .column {
     padding: 20px;
 }
+
+.owner_profile:visited, .owner_profile {
+    color: #000000; }
+.owner_profile:focus, .owner_profile:hover {
+    color: #e9573f; }
+
 /* On screens that are 992px wide or less */
 @media screen and (max-width: 992px) {
     .l-column {

--- a/app/assets/stylesheets/modules/owners.css
+++ b/app/assets/stylesheets/modules/owners.css
@@ -1,0 +1,155 @@
+.owners__wrapper {
+    margin: 0 auto;
+    padding: 10px 0 10px 10px;
+    max-width: 800px;
+}
+.owners__navigation {
+    display: inline-block;
+    width: 100%;
+}
+.owners__navigation a {
+    color: #9da2ab;
+    text-transform: uppercase;
+    font-weight: bold;
+    transition-duration: 0.25s;
+    transition-property: color;
+    outline: none;
+}
+.owners__navigation a:hover, .owners__navigation a:focus, .owners__navigation a:active {
+    color: #141c22;
+}
+.owners__back__navigation.disabled:hover {
+    color: #9da2ab;
+}
+.owners__back__navigation {
+    float: left;
+}
+.owners__table {
+    width: 100%;
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+    border-spacing: 0;
+}
+@media screen and (max-width: 580px) {
+    .owners__table {
+        display: block;
+    }
+}
+.owners__tbody {
+    display: block;
+}
+.owners__row {
+    background: #ffffff;
+}
+.owners__row:nth-of-type(odd) {
+    background: #f6f6f6;
+}
+.owners__row.owners__header {
+    font-weight: 900;
+    color: #ffffff;
+    background: #e9573f;
+}
+@media screen and (max-width: 580px) {
+    .owners__row {
+        padding: 14px 0 7px;
+        display: block;
+    }
+    .owners__row.owners__header {
+        padding: 0;
+        height: 6px;
+    }
+    .owners__row.owners__header .owners__cell {
+        display: none;
+    }
+    .owners__row .owners__cell {
+        margin-bottom: 10px;
+    }
+    .owners__row .owners__cell:before {
+        margin-bottom: 3px;
+        content: attr(data-title);
+        min-width: 98px;
+        font-size: 10px;
+        line-height: 10px;
+        font-weight: bold;
+        text-transform: uppercase;
+        color: #969696;
+        display: block;
+    }
+}
+.owners__cell {
+    padding: 13px 12px;
+    text-align: center;
+}
+@media screen and (max-width: 580px) {
+    .owners__cell {
+        padding: 2px 16px;
+        display: block;
+    }
+}
+.remove__owners__button {
+    -webkit-appearance: none;
+    position: relative;
+    display: inline-block;
+    border-radius: 20px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    outline: none;
+    transition-duration: 0.25s;
+    transition-property: border-color, background-color;
+    width: 100%;
+    max-width: 320px;
+    background-color: #e9573f;
+    color: #ffffff;
+}
+.remove__owners__button:hover {
+    opacity: .7;
+}
+.add__owners__button {
+    -webkit-appearance: none;
+    position: relative;
+    display: block;
+    border-radius: 20px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    outline: none;
+    transition-duration: 0.25s;
+    margin-top: 22px;
+    margin-bottom: 80px;
+    width: 100%;
+    max-width: 320px;
+    background-color: #e9573f;
+    color: #ffffff;
+    transition-property: opacity;
+    padding: 8px 0;
+}
+.add__owners__button:hover {
+    opacity: .7;
+}
+
+.add_owner__field {
+    max-width: 160px;
+}
+/* Container for flex box */
+.row {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.column {
+    padding: 20px;
+}
+/* On screens that are 992px wide or less */
+@media screen and (max-width: 992px) {
+    .l-column {
+        flex: 75%;
+        border-right: 5px;
+    }
+    .r-column {
+        flex: 25%;
+    }
+}
+/* On screens that are 600px wide or less, make the columns stack on top of each other instead of next to each other */
+@media screen and (max-width: 600px) {
+    .row {
+        flex-direction: column;
+    }
+}

--- a/app/assets/stylesheets/modules/owners.css
+++ b/app/assets/stylesheets/modules/owners.css
@@ -1,11 +1,9 @@
 .owners__wrapper {
     margin: 0 auto;
-    padding: 10px 0 10px 10px;
-    max-width: 800px;
 }
+
 .owners__navigation {
     display: inline-block;
-    width: 100%;
 }
 .owners__navigation a {
     color: #9da2ab;
@@ -13,147 +11,88 @@
     font-weight: bold;
     transition-duration: 0.25s;
     transition-property: color;
-    outline: none;
-}
+    outline: none; }
 .owners__navigation a:hover, .owners__navigation a:focus, .owners__navigation a:active {
-    color: #141c22;
-}
-.owners__back__navigation.disabled:hover {
-    color: #9da2ab;
-}
-.owners__back__navigation {
-    float: left;
-}
+    color: #141c22; }
+
+.owners__back_navigation.disabled:hover {
+    color: #9da2ab; }
+.owners__back_navigation {
+    float: left; }
+
 .owners__table {
-    width: 100%;
-    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
     border-spacing: 0;
     font-size: 16px;
+    width: 100%;
+    display: table;
+    text-align: center;
 }
-@media screen and (max-width: 580px) {
-    .owners__table {
-        display: block;
-    }
-}
-.owners__tbody {
-    display: block;
-}
-.owners__row {
-    background: #ffffff;
-}
+
 .owners__row:nth-of-type(odd) {
-    background: #f6f6f6;
-}
+    background: #f6f6f6; }
 .owners__row.owners__header {
     font-weight: 900;
     color: #ffffff;
-    background: #e9573f;
-}
-@media screen and (max-width: 580px) {
+    background: #e9573f; }
+
+.owners__cell {
+    padding: 9px 5px; }
+
+.owners__btn--remove {
+    border: none;
+    padding: 9px 12px;
+    margin: 4px 2px;
+    cursor: pointer;
+    border-radius: 20px;
+    transition-duration: 0.25s;
+    transition-property: border-color, background-color;
+    background-color: #e9573f;
+    color: #ffffff; }
+.owners__btn--remove:hover {
+    opacity: .7; }
+
+@media only screen and (max-width: 500px) {
     .owners__row {
         padding: 14px 0 7px;
-        display: block;
-    }
+        display: block; }
     .owners__row.owners__header {
         padding: 0;
-        height: 6px;
-    }
+        height: 6px; }
     .owners__row.owners__header .owners__cell {
-        display: none;
-    }
+        display: none; }
     .owners__row .owners__cell {
-        margin-bottom: 10px;
-    }
+        margin-bottom: 10px; }
     .owners__row .owners__cell:before {
         margin-bottom: 3px;
         content: attr(data-title);
         min-width: 98px;
         text-transform: uppercase;
         color: #969696;
-        display: block;
-    }
-}
-.owners__cell {
-    padding: 13px 12px;
-    text-align: center;
-}
-@media screen and (max-width: 580px) {
+        display: block; }
+
     .owners__cell {
         padding: 2px 16px;
         display: block;
     }
 }
-.remove__owners__button {
-    -webkit-appearance: none;
-    position: relative;
-    display: inline-block;
-    border-radius: 20px;
-    border: 1px solid transparent;
-    cursor: pointer;
-    outline: none;
-    transition-duration: 0.25s;
-    transition-property: border-color, background-color;
-    width: 100%;
-    max-width: 320px;
-    background-color: #e9573f;
-    color: #ffffff;
-}
-.remove__owners__button:hover {
-    opacity: .7;
-}
-.add__owners__button {
-    -webkit-appearance: none;
-    position: relative;
-    display: block;
-    border-radius: 20px;
-    border: 1px solid transparent;
-    cursor: pointer;
-    outline: none;
-    transition-duration: 0.25s;
-    margin-top: 22px;
-    margin-bottom: 80px;
-    width: 100%;
-    max-width: 320px;
-    background-color: #e9573f;
-    color: #ffffff;
-    transition-property: opacity;
-    padding: 8px 0;
-}
-.add__owners__button:hover {
-    opacity: .7;
-}
 
-.add_owner__field {
-    max-width: 320px;
-}
-/* Container for flex box */
-.row {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.column {
-    padding: 20px;
-}
+.ownership__green {
+    color: green; }
+.ownership__blue {
+    color: #187ac9; }
+.ownership__red {
+    color: #e9573f; }
 
 .owner_profile:visited, .owner_profile {
     color: #000000; }
 .owner_profile:focus, .owner_profile:hover {
     color: #e9573f; }
 
-/* On screens that are 992px wide or less */
-@media screen and (max-width: 992px) {
-    .l-column {
-        flex: 75%;
-        border-right: 5px;
-    }
-    .r-column {
-        flex: 25%;
-    }
-}
-/* On screens that are 600px wide or less, make the columns stack on top of each other instead of next to each other */
-@media screen and (max-width: 600px) {
-    .row {
-        flex-direction: column;
-    }
-}
+.owners__intro {
+    margin: 10px 0 32px 0;
+    padding-bottom: 30px;
+    border-bottom: 1px solid #c1c4ca;
+    font-size: 16px;
+    font-weight: 300;
+    line-height: 1.5; }
+

--- a/app/assets/stylesheets/modules/tooltip.css
+++ b/app/assets/stylesheets/modules/tooltip.css
@@ -1,0 +1,76 @@
+.tooltip {
+    display: inline;
+    position: relative;
+    z-index: 999; }
+
+.tooltip-item {
+    cursor: pointer;
+    display: inline-block; }
+.tooltip-item::after {
+    content: '';
+    position: absolute;
+    width: 360px;
+    height: 20px;
+    bottom: 100%;
+    pointer-events: none;
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%); }
+.tooltip:hover .tooltip-item::after {
+    pointer-events: auto; }
+
+.tooltip-content {
+    position: absolute;
+    z-index: 9999;
+    width: 360px;
+    left: 50%;
+    bottom: 150%;
+    text-align: left;
+    font-size: 14px;
+    line-height: 1.4;
+    box-shadow: 5px 5px 20px rgba(0, 0, 0, 0.2);
+    background: #f8f8f9;
+    opacity: 0;
+    cursor: default;
+    pointer-events: none;
+    border-radius: 0 5px 5px 0; }
+.tooltip-content::after {
+    content: '';
+    top: 100%;
+    left: 50%;
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    border: 10px solid transparent;
+    margin-left: -10px; }
+.tooltip-content img {
+    position: relative;
+    display: block;
+    float: left;
+    margin-right: 1em;
+    border-radius: 5px 0 0 5px; }
+
+.tooltip-effect .tooltip-content {
+    -webkit-transform: translate3d(0,-10px,0);
+    transform: translate3d(0,-10px,0);
+    -webkit-transition: opacity 0.3s, -webkit-transform 0.3s;
+    transition: opacity 0.3s, transform 0.3s; }
+
+.tooltip:hover .tooltip-content {
+    pointer-events: auto;
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) rotate3d(0,0,0,0);
+    transform: translate3d(0,0,0) rotate3d(0,0,0,0); }
+
+.tooltip-text {
+    font-size: 1em;
+    line-height: 1.35;
+    display: block;
+    padding: 1em 1em 1em 0;
+    color: #000000; }
+
+.tooltip-title {
+    font-size: 1.5em; }
+
+.tooltip-subtitle {
+    font-size: 1em; }

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::OwnersController < Api::BaseController
   def create
     owner = User.find_by_name(params[:email])
     if owner
-      ownership = Ownership.create_unconfirmed(@rubygem, owner, @api_user)
+      ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_user)
       if ownership.save
         Mailer.delay.ownership_confirmation(ownership.id)
         render plain: "Owner added successfully. A confirmation mail has been sent to #{owner.handle}'s email"

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -6,22 +6,20 @@ class Api::V1::OwnersController < Api::BaseController
 
   def show
     respond_to do |format|
-      format.json { render json: @rubygem.confirmed_owners }
-      format.yaml { render yaml: @rubygem.confirmed_owners }
+      format.json { render json: @rubygem.owners }
+      format.yaml { render yaml: @rubygem.owners }
     end
   end
 
   def create
     owner = User.find_by_name(params[:email])
-    return if verify_ownership_exists(owner)
     if owner
-      ownership = @rubygem.ownerships.first_or_initialize(user: owner)
-      ownership.generate_confirmation_token
+      ownership = Ownership.create_unconfirmed(@rubygem, owner, @api_user)
       if ownership.save
         Mailer.delay.ownership_confirmation(ownership.id)
-        render plain: "Owner added successfully. A confirmation mail has been sent to #{owner.email}"
+        render plain: "Owner added successfully. A confirmation mail has been sent to #{owner.handle}'s email"
       else
-        render plain: "Failed to add owner", status: :forbidden
+        render plain: ownership.errors.full_messages.to_sentence, status: :unprocessable_entity
       end
     else
       render plain: "Owner could not be found.", status: :not_found
@@ -29,10 +27,10 @@ class Api::V1::OwnersController < Api::BaseController
   end
 
   def destroy
-    owner = @rubygem.owners.find_by_name(params[:email])
+    owner = @rubygem.owners_including_unconfirmed.find_by_name(params[:email])
     if owner
       ownership = @rubygem.ownerships.find_by(user_id: owner.id)
-      if ownership&.safe_destroy
+      if ownership&.destroy_and_notify
         render plain: "Owner removed successfully."
       else
         render plain: "Unable to remove owner.", status: :forbidden
@@ -60,9 +58,5 @@ class Api::V1::OwnersController < Api::BaseController
   def verify_gem_ownership
     return if @api_user.rubygems.find_by_name(params[:rubygem_id])
     render plain: "You do not have permission to manage this gem.", status: :unauthorized
-  end
-
-  def verify_ownership_exists(owner)
-    render plain: "The user is already an owner.", status: :forbidden if @rubygem.owned_by?(owner)
   end
 end

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -6,15 +6,20 @@ class NotifiersController < ApplicationController
   end
 
   def update
-    to_enable = []
-    to_disable = []
+    to_enable_push = []
+    to_disable_push = []
+    to_enable_owner = []
+    to_disable_owner = []
     params.require(:ownerships).each do |ownership_id, notifier|
-      (notifier == "off" ? to_disable : to_enable) << ownership_id.to_i
+      (notifier["owner"] == "off" ? to_disable_owner : to_enable_owner) << ownership_id.to_i
+      (notifier["push"] == "off" ? to_disable_push : to_enable_push) << ownership_id.to_i
     end
 
     current_user.transaction do
-      current_user.ownerships.where(id: to_enable).update_all(push_notifier: true) if to_enable.any?
-      current_user.ownerships.where(id: to_disable).update_all(push_notifier: false) if to_disable.any?
+      current_user.ownerships.where(id: to_enable_push).update_all(push_notifier: true) if to_enable_push.any?
+      current_user.ownerships.where(id: to_disable_push).update_all(push_notifier: false) if to_disable_push.any?
+      current_user.ownerships.where(id: to_enable_owner).update_all(owner_notifier: true) if to_enable_owner.any?
+      current_user.ownerships.where(id: to_disable_owner).update_all(owner_notifier: false) if to_disable_owner.any?
       Mailer.delay.notifiers_changed(current_user.id)
     end
 

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -13,8 +13,8 @@ class NotifiersController < ApplicationController
     end
 
     current_user.transaction do
-      current_user.ownerships.where(id: to_enable).update_all(notifier: true) if to_enable.any?
-      current_user.ownerships.where(id: to_disable).update_all(notifier: false) if to_disable.any?
+      current_user.ownerships.where(id: to_enable).update_all(push_notifier: true) if to_enable.any?
+      current_user.ownerships.where(id: to_disable).update_all(push_notifier: false) if to_disable.any?
       Mailer.delay.notifiers_changed(current_user.id)
     end
 

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,22 +1,60 @@
 class OwnersController < ApplicationController
-  before_action :find_rubygem, except: :gems
+  before_action :find_rubygem, except: :confirm
+  before_action :set_ownership, only: :destroy
+  before_action :render_not_found, unless: :owner?, except: %i[confirm resend_confirmation]
 
   def confirm
     ownership = Ownership.includes(:rubygem).find_by(token: params[:token])
 
-    if ownership&.valid_confirmation_token? && ownership&.confirm_ownership! && ownership&.notify_ownership_change("added")
-      sign_in ownership.user
-      redirect_to root_path, notice: t(".confirm.confirmed_email", gem: ownership.rubygem.name)
+    if ownership&.valid_confirmation_token?
+      ownership.confirm_and_notify
+      redirect_to rubygem_path(ownership.rubygem), notice: t(".confirm.confirmed_email", gem: ownership.rubygem.name)
     else
-      redirect_to root_path, alert: t("failure_when_forbidden")
+      redirect_to root_path, alert: t("token_expired")
     end
   end
 
-  def index
-    @owners = @rubygem.owners
+  def resend_confirmation
+    ownership = @rubygem.ownerships.find_by(user: current_user)
+    Mailer.delay.ownership_confirmation(ownership.id)
+    redirect_to rubygem_path(ownership.rubygem), notice: "A confirmation mail has been re-sent to #{ownership.user.handle}'s email"
   end
 
-  private
+  def index
+    @ownerships = @rubygem.ownerships.includes(:user, :authorizer)
+  end
 
+  def create
+    owner = User.find_by_name(params[:owner])
+    if owner
+      ownership = Ownership.create_unconfirmed(@rubygem, owner, current_user)
+      if ownership.save
+        Mailer.delay.ownership_confirmation(ownership.id)
+        redirect_to rubygem_owners_path(@rubygem), notice: "Owner added successfully. A confirmation mail has been sent to #{owner.handle}'s email"
+      else
+        redirect_to rubygem_owners_path(@rubygem), alert: ownership.errors.full_messages.to_sentence
+      end
+    else
+      redirect_to rubygem_owners_path(@rubygem), alert: "Owner could not be found."
+    end
+  end
 
+  def destroy
+    if @ownership.destroy_and_notify
+      redirect_to rubygem_owners_path(@ownership.rubygem), notice: "Owner #{@ownership.user.name} removed successfully!"
+    else
+      redirect_to rubygem_owners_path(@ownership.rubygem), notice: "Owner cannot be removed!"
+    end
+  end
+
+  protected
+
+  def set_ownership
+    @ownership = Ownership.find(params[:id] || params[:owners_id])
+    render_not_found unless @ownership
+  end
+
+  def owner?
+    @rubygem.owned_by?(current_user)
+  end
 end

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,0 +1,22 @@
+class OwnersController < ApplicationController
+  before_action :find_rubygem, except: :gems
+
+  def confirm
+    ownership = Ownership.includes(:rubygem).find_by(token: params[:token])
+
+    if ownership&.valid_confirmation_token? && ownership&.confirm_ownership! && ownership&.notify_ownership_change("added")
+      sign_in ownership.user
+      redirect_to root_path, notice: t(".confirm.confirmed_email", gem: ownership.rubygem.name)
+    else
+      redirect_to root_path, alert: t("failure_when_forbidden")
+    end
+  end
+
+  def index
+    @owners = @rubygem.owners
+  end
+
+  private
+
+
+end

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -15,7 +15,7 @@ class OwnersController < ApplicationController
   end
 
   def resend_confirmation
-    ownership = @rubygem.ownerships.find_by(user: current_user)
+    ownership = @rubygem.ownerships_including_unconfirmed.find_by(user: current_user)
     if ownership&.generate_confirmation_token && ownership&.save
       Mailer.delay.ownership_confirmation(ownership.id)
       redirect_to rubygem_path(ownership.rubygem), notice: "A confirmation mail has been re-sent to #{ownership.user.handle}'s email"
@@ -25,7 +25,7 @@ class OwnersController < ApplicationController
   end
 
   def index
-    @ownerships = @rubygem.ownerships.includes(:user, :authorizer)
+    @ownerships = @rubygem.ownerships_including_unconfirmed.includes(:user, :authorizer)
   end
 
   def create

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -29,7 +29,7 @@ class OwnersController < ApplicationController
   end
 
   def create
-    owner = User.find_by_name(params[:owner])
+    owner = User.find_by_name(params.dig(:ownership, :email))
     if owner
       ownership = @rubygem.ownerships.new(user: owner, authorizer: current_user)
       if ownership.save

--- a/app/helpers/owners_helper.rb
+++ b/app/helpers/owners_helper.rb
@@ -1,0 +1,19 @@
+module OwnersHelper
+  def confirmation_status(ownership)
+    if ownership.confirmed?
+      content_tag(:span, "Confirmed", data: { icon: "✔ " }, class: "ownership__green")
+    elsif ownership.expired?
+      content_tag(:span, "Expired", data: { icon: "✗ " }, class: "ownership__red")
+    else
+      content_tag(:span, "Pending", data: { icon: "⧖ " }, class: "ownership__blue")
+    end
+  end
+
+  def mfa_status(user)
+    if user.mfa_level == "disabled"
+      content_tag(:span, "Disabled", data: { icon: "🔓 " }, class: "ownership__red")
+    else
+      content_tag(:span, "Enabled", data: { icon: "🔒 " }, class: "ownership__green")
+    end
+  end
+end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -78,6 +78,10 @@ module RubygemsHelper
     link_to t(".links.report_abuse"), report_abuse_url.html_safe, class: "gem__link t-list__item"
   end
 
+  def ownership_link(rubygem)
+    link_to "Ownership", rubygem_owners_path(rubygem), class: "gem__link t-list__item"
+  end
+
   def links_to_owners(rubygem)
     rubygem.owners.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
   end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -82,6 +82,10 @@ module RubygemsHelper
     link_to "Ownership", rubygem_owners_path(rubygem), class: "gem__link t-list__item"
   end
 
+  def resend_owner_confirmation_link(rubygem)
+    link_to "Resend Ownership Confirmation", resend_confirmation_rubygem_owners_url(rubygem), class: "gem__link t-list__item"
+  end
+
   def links_to_owners(rubygem)
     rubygem.owners.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
   end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -70,4 +70,22 @@ class Mailer < ApplicationMailer
     mail to: @user.email,
          subject: I18n.t("mailer.reset_api_key.subject")
   end
+
+  def ownership_confirmation(ownership_id)
+    @ownership = Ownership.find(ownership_id)
+    @user = @ownership.user
+    @rubygem = @ownership.rubygem
+    mail to: @user.email,
+         subject: I18n.t("mailer.ownership_confirmation.subject", gem: @rubygem.name,
+                         default: "Please confirm the ownership of %{gem} gem on RubyGems.org")
+  end
+
+  def owners_update(owner_id, user_id, status, gem_id)
+    @user = User.find(user_id)
+    @owner = User.find(owner_id)
+    @rubygem = Rubygem.find(gem_id)
+    @status = status
+    mail to: @user.email,
+         subject: @owner.id == @user.id ? I18n.t("mailer.owners_update.subject_self", status: status, gem: @rubygem.name) : I18n.t("mailer.owners_update.subject_others", status: status, gem: @rubygem.name, owner_handle: @owner.handle)
+  end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -80,12 +80,27 @@ class Mailer < ApplicationMailer
                          default: "Please confirm the ownership of %{gem} gem on RubyGems.org")
   end
 
-  def owners_update(owner_id, user_id, status, gem_id)
+  def owner_removed(owner_id, user_id, gem_id)
     @user = User.find(user_id)
     @owner = User.find(owner_id)
     @rubygem = Rubygem.find(gem_id)
-    @status = status
     mail to: @user.email,
-         subject: @owner.id == @user.id ? I18n.t("mailer.owners_update.subject_self", status: status, gem: @rubygem.name) : I18n.t("mailer.owners_update.subject_others", status: status, gem: @rubygem.name, owner_handle: @owner.handle)
+         subject: if @owner.id == @user.id
+                    I18n.t("mailer.owners_update.subject_self", gem: @rubygem.name, status: "removed")
+                  else
+                    I18n.t("mailer.owners_update.subject_others", gem: @rubygem.name, status: "removed", owner_handle: @owner.handle)
+                  end
+  end
+
+  def owner_added(owner_id, user_id, gem_id)
+    @user = User.find(user_id)
+    @owner = User.find(owner_id)
+    @rubygem = Rubygem.find(gem_id)
+    mail to: @user.email,
+         subject: if @owner.id == @user.id
+                    I18n.t("mailer.owners_update.subject_self", gem: @rubygem.name, status: "added")
+                  else
+                    I18n.t("mailer.owners_update.subject_others", gem: @rubygem.name, status: "added", owner_handle: @owner.handle)
+                  end
   end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -85,11 +85,7 @@ class Mailer < ApplicationMailer
     @owner = User.find(owner_id)
     @rubygem = Rubygem.find(gem_id)
     mail to: @user.email,
-         subject: if @owner.id == @user.id
-                    I18n.t("mailer.owners_update.subject_self", gem: @rubygem.name, status: "removed")
-                  else
-                    I18n.t("mailer.owners_update.subject_others", gem: @rubygem.name, status: "removed", owner_handle: @owner.handle)
-                  end
+         subject: owner_removed_subject
   end
 
   def owner_added(owner_id, user_id, gem_id)
@@ -97,10 +93,24 @@ class Mailer < ApplicationMailer
     @owner = User.find(owner_id)
     @rubygem = Rubygem.find(gem_id)
     mail to: @user.email,
-         subject: if @owner.id == @user.id
-                    I18n.t("mailer.owners_update.subject_self", gem: @rubygem.name, status: "added")
-                  else
-                    I18n.t("mailer.owners_update.subject_others", gem: @rubygem.name, status: "added", owner_handle: @owner.handle)
-                  end
+         subject: owner_added_subject
+  end
+
+  private
+
+  def owner_added_subject
+    if @owner.id == @user.id
+      I18n.t("mailer.owner_added.subject_self", gem: @rubygem.name)
+    else
+      I18n.t("mailer.owner_added.subject_others", gem: @rubygem.name, owner_handle: @owner.handle)
+    end
+  end
+
+  def owner_removed_subject
+    if @owner.id == @user.id
+      I18n.t("mailer.owner_removed.subject_self", gem: @rubygem.name)
+    else
+      I18n.t("mailer.owner_removed.subject_others", gem: @rubygem.name, owner_handle: @owner.handle)
+    end
   end
 end

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -12,7 +12,28 @@ class Ownership < ApplicationRecord
       .order("rubygems.name ASC")
   end
 
+  def valid_confirmation_token?
+    token_expires_at > Time.zone.now
+  end
+
+  def generate_confirmation_token
+    self.token = SecureRandom.hex(20).encode("UTF-8")
+    self.token_expires_at = Time.zone.now + Gemcutter::OWNERSHIP_TOKEN_EXPIRES_AFTER
+  end
+
+  def confirm_ownership!
+    update(confirmed: true)
+  end
+
+  def notify_ownership_change(status)
+    rubygem.notifiable_owners.each do |notified_user|
+      Mailer.delay.owners_update(user_id, notified_user.id, status, rubygem_id)
+    end
+  end
+
   def safe_destroy
     rubygem.owners.many? && destroy
+    Mailer.delay.owners_update(user_id, user_id, "removed", rubygem_id)
+    notify_ownership_change("removed")
   end
 end

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -7,6 +7,9 @@ class Ownership < ApplicationRecord
 
   before_create :generate_confirmation_token
 
+  scope :confirmed, -> { where("confirmed_at IS NOT NULL") }
+  scope :unconfirmed, -> { where("confirmed_at IS NULL") }
+
   def self.by_indexed_gem_name
     select("ownerships.*, rubygems.name")
       .left_joins(rubygem: :versions)
@@ -14,13 +17,6 @@ class Ownership < ApplicationRecord
       .distinct
       .order("rubygems.name ASC")
   end
-
-  # def self.create_unconfirmed(rubygem, owner, authorizer)
-  #   ownership = rubygem.ownerships.new(user: owner)
-  #   ownership.generate_confirmation_token
-  #   ownership.authorizer_id = authorizer.id
-  #   ownership
-  # end
 
   def valid_confirmation_token?
     token_expires_at > Time.zone.now
@@ -36,9 +32,7 @@ class Ownership < ApplicationRecord
   end
 
   def confirmed?
-    return true if confirmed_at.present?
-
-    false
+    confirmed_at.present?
   end
 
   def unconfirmed?

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -39,6 +39,10 @@ class Ownership < ApplicationRecord
     !confirmed?
   end
 
+  def expired?
+    !confirmed? && !valid_confirmation_token?
+  end
+
   def notify_owner_removed
     rubygem.notifiable_owners.each do |notified_user|
       Mailer.delay.owner_removed(user_id, notified_user.id, rubygem_id)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -200,7 +200,7 @@ class Rubygem < ApplicationRecord
   end
 
   def create_ownership(user)
-    ownerships.create(user: user) if unowned?
+    ownerships.create(user: user, confirmed: true) if unowned?
   end
 
   def update_versions!(version, spec)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -3,8 +3,8 @@ class Rubygem < ApplicationRecord
   include RubygemSearchable
 
   has_many :ownerships, dependent: :destroy
-  has_many :owners, through: :ownerships, source: :user
-  has_many :confirmed_owners, ->(gem) { gem.owners.confirmed_owners }, through: :ownerships, source: :user
+  has_many :owners_including_unconfirmed, through: :ownerships, source: :user
+  has_many :owners, ->(gem) { gem.owners_including_unconfirmed.confirmed_owners }, through: :ownerships, source: :user
   has_many :notifiable_owners, ->(gem) { gem.owners.notifiable_owners }, through: :ownerships, source: :user
   has_many :subscriptions, dependent: :destroy
   has_many :subscribers, through: :subscriptions, source: :user
@@ -138,12 +138,12 @@ class Rubygem < ApplicationRecord
 
   def owned_by?(user)
     return false unless user
-    ownerships.exists?(user_id: user.id, confirmed: true)
+    ownerships.where(user_id: user.id).where.not(confirmed_at: nil).exists?
   end
 
   def unconfirmed_ownership?(user)
     return false unless user
-    ownerships.exists?(user_id: user.id, confirmed: false)
+    ownerships.where(user_id: user.id, confirmed_at: nil).exists?
   end
 
   def to_s
@@ -206,7 +206,7 @@ class Rubygem < ApplicationRecord
   end
 
   def create_ownership(user)
-    ownerships.create(user: user, confirmed: true) if unowned?
+    ownerships.create(user: user, confirmed_at: Time.current, authorizer: user) if unowned?
   end
 
   def update_versions!(version, spec)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -4,6 +4,7 @@ class Rubygem < ApplicationRecord
 
   has_many :ownerships, dependent: :destroy
   has_many :owners, through: :ownerships, source: :user
+  has_many :confirmed_owners, ->(gem) { gem.owners.confirmed_owners }, through: :ownerships, source: :user
   has_many :notifiable_owners, ->(gem) { gem.owners.notifiable_owners }, through: :ownerships, source: :user
   has_many :subscriptions, dependent: :destroy
   has_many :subscribers, through: :subscriptions, source: :user
@@ -137,7 +138,12 @@ class Rubygem < ApplicationRecord
 
   def owned_by?(user)
     return false unless user
-    ownerships.exists?(user_id: user.id)
+    ownerships.exists?(user_id: user.id, confirmed: true)
+  end
+
+  def unconfirmed_ownership?(user)
+    return false unless user
+    ownerships.exists?(user_id: user.id, confirmed: false)
   end
 
   def to_s

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
   end
 
   def self.notifiable_owners
-    where(ownerships: { notifier: true })
+    where(ownerships: { push_notifier: true })
   end
 
   def self.without_mfa

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,10 @@ class User < ApplicationRecord
     where(ownerships: { push_notifier: true })
   end
 
+  def self.confirmed_owners
+    where(ownerships: { confirmed: true })
+  end
+
   def self.without_mfa
     where(mfa_level: "disabled")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,9 +16,10 @@ class User < ApplicationRecord
 
   before_destroy :yank_gems
 
-  has_many :ownerships, dependent: :destroy
-  has_many :rubygems, -> { where("ownerships.confirmed_at IS NOT NULL") }, through: :ownerships
+  has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :user
+  has_many :ownerships_including_unconfirmed, dependent: :destroy, inverse_of: :user, class_name: "Ownership"
 
+  has_many :rubygems, through: :ownerships, source: :rubygem
   has_many :subscriptions, dependent: :destroy
   has_many :subscribed_gems, -> { order("name ASC") }, through: :subscriptions, source: :rubygem
 
@@ -67,10 +68,6 @@ class User < ApplicationRecord
 
   def self.notifiable_owners
     where(ownerships: { push_notifier: true })
-  end
-
-  def self.confirmed_owners
-    where.not(ownerships: { confirmed_at: nil })
   end
 
   def self.without_mfa
@@ -234,10 +231,6 @@ class User < ApplicationRecord
         api_key: nil
       )
     end
-  end
-
-  def unconfirmed_ownership(rubygem)
-    rubygem.ownerships.find_by(user: self, confirmed_at: nil)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   before_destroy :yank_gems
 
   has_many :ownerships, dependent: :destroy
-  has_many :rubygems, through: :ownerships
+  has_many :rubygems, -> { where("ownerships.confirmed_at IS NOT NULL") }, through: :ownerships
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscribed_gems, -> { order("name ASC") }, through: :subscriptions, source: :rubygem
@@ -70,7 +70,7 @@ class User < ApplicationRecord
   end
 
   def self.confirmed_owners
-    where(ownerships: { confirmed: true })
+    where.not(ownerships: { confirmed_at: nil })
   end
 
   def self.without_mfa
@@ -234,6 +234,10 @@ class User < ApplicationRecord
         api_key: nil
       )
     end
+  end
+
+  def unconfirmed_ownership(rubygem)
+    rubygem.ownerships.find_by(user: self, confirmed_at: nil)
   end
 
   private

--- a/app/views/mailer/notifiers_changed.html.erb
+++ b/app/views/mailer/notifiers_changed.html.erb
@@ -21,7 +21,7 @@
           <% @ownerships.each do |ownership| %>
             <li>
               <%= ownership.rubygem.name %> emails:
-              <%= ownership.notifier? ? 'ON' : '<strong>OFF</strong>'.html_safe %>
+              <%= ownership.push_notifier? ? 'ON' : '<strong>OFF</strong>'.html_safe %>
             </li>
           <% end %>
         </ul>

--- a/app/views/mailer/owner_added.html.erb
+++ b/app/views/mailer/owner_added.html.erb
@@ -1,0 +1,44 @@
+<% @title = t("mailer.owners_update.title") %>
+<% @sub_title = t("mailer.owners_update.subtitle", user_handle: @user.handle) %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <br>
+        <p>
+          <%= @owner.id == @user.id ? I18n.t("mailer.owners_update.body_self", status: "added", gem: @rubygem.name) : I18n.t("mailer.owners_update.body_others", status: "added", gem: @rubygem.name, owner_handle: @owner.handle) %>
+        </p>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+        <p>
+          Update your notification settings if you want to stop receiving owner change emails
+        </p>
+        <p>If this change is expected, you do not need to take further action.</p>
+        <p>
+          <strong>Only if this change is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+        <ol>
+          <li>If you suspect your account was compromised:
+            <ul>
+              <li><%= link_to("Change your password", new_password_url) %></li>
+              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
+              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
+              <li><%= link_to("Renable email notification for your gem", notifier_url) %></li>
+            </ul>
+          </li>
+          <li>Look out for unexpected changes to your gems on RubyGems.org</li>
+          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
+        </ol>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>

--- a/app/views/mailer/owner_added.html.erb
+++ b/app/views/mailer/owner_added.html.erb
@@ -1,5 +1,5 @@
-<% @title = t("mailer.owners_update.title") %>
-<% @sub_title = t("mailer.owners_update.subtitle", user_handle: @user.handle) %>
+<% @title = t("mailer.owner_added.title") %>
+<% @sub_title = t("mailer.owner_added.subtitle", user_handle: @user.handle) %>
 
 <!-- Body -->
 <table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
@@ -9,29 +9,25 @@
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
         <br>
         <p>
-          <%= @owner.id == @user.id ? I18n.t("mailer.owners_update.body_self", status: "added", gem: @rubygem.name) : I18n.t("mailer.owners_update.body_others", status: "added", gem: @rubygem.name, owner_handle: @owner.handle) %>
+          <%= @owner.id == @user.id ? I18n.t("mailer.owner_added.body_self", gem: @rubygem.name) : I18n.t("mailer.owner_added.body_others", gem: @rubygem.name, owner_handle: @owner.handle) %>
         </p>
         <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-        <p>
-          Update your notification settings if you want to stop receiving owner change emails
-        </p>
+
         <p>If this change is expected, you do not need to take further action.</p>
         <p>
           <strong>Only if this change is unexpected</strong>
           please take immediate steps to secure your account and gems:
         </p>
-        <ol>
-          <li>If you suspect your account was compromised:
-            <ul>
-              <li><%= link_to("Change your password", new_password_url) %></li>
-              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
-              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
-              <li><%= link_to("Renable email notification for your gem", notifier_url) %></li>
-            </ul>
-          </li>
+
+        <%= render "compromised_instructions" do %>
           <li>Look out for unexpected changes to your gems on RubyGems.org</li>
-          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
-        </ol>
+        <% end %>
+
+        <p>
+          <em>
+            To stop receiving these messages, update your <%= link_to("email notification settings", notifier_url) %>.
+          </em>
+        </p>
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/app/views/mailer/owner_removed.html.erb
+++ b/app/views/mailer/owner_removed.html.erb
@@ -1,5 +1,5 @@
-<% @title = t(".title") %>
-<% @sub_title = t(".subtitle", user_handle: @user.handle) %>
+<% @title = t("mailer.owners_update.title") %>
+<% @sub_title = t("mailer.owners_update.subtitle", user_handle: @user.handle) %>
 
 <!-- Body -->
 <table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
@@ -9,7 +9,7 @@
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
         <br>
         <p>
-          <%= @owner.id == @user.id ? I18n.t("mailer.owners_update.body_self", status: @status, gem: @rubygem.name) : I18n.t("mailer.owners_update.body_others", status: @status, gem: @rubygem.name, owner_handle: @owner.handle) %>
+          <%= @owner.id == @user.id ? I18n.t("mailer.owners_update.body_self", status: "removed", gem: @rubygem.name) : I18n.t("mailer.owners_update.body_others", status: "removed", gem: @rubygem.name, owner_handle: @owner.handle) %>
         </p>
         <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
         <p>

--- a/app/views/mailer/owner_removed.html.erb
+++ b/app/views/mailer/owner_removed.html.erb
@@ -1,5 +1,5 @@
-<% @title = t("mailer.owners_update.title") %>
-<% @sub_title = t("mailer.owners_update.subtitle", user_handle: @user.handle) %>
+<% @title = t("mailer.owner_removed.title") %>
+<% @sub_title = t("mailer.owner_removed.subtitle", user_handle: @user.handle) %>
 
 <!-- Body -->
 <table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
@@ -9,29 +9,25 @@
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
         <br>
         <p>
-          <%= @owner.id == @user.id ? I18n.t("mailer.owners_update.body_self", status: "removed", gem: @rubygem.name) : I18n.t("mailer.owners_update.body_others", status: "removed", gem: @rubygem.name, owner_handle: @owner.handle) %>
+          <%= @owner.id == @user.id ? I18n.t("mailer.owner_removed.body_self", gem: @rubygem.name) : I18n.t("mailer.owner_removed.body_others", gem: @rubygem.name, owner_handle: @owner.handle) %>
         </p>
         <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-        <p>
-          Update your notification settings if you want to stop receiving owner change emails
-        </p>
+
         <p>If this change is expected, you do not need to take further action.</p>
         <p>
           <strong>Only if this change is unexpected</strong>
           please take immediate steps to secure your account and gems:
         </p>
-        <ol>
-          <li>If you suspect your account was compromised:
-            <ul>
-              <li><%= link_to("Change your password", new_password_url) %></li>
-              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
-              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
-              <li><%= link_to("Renable email notification for your gem", notifier_url) %></li>
-            </ul>
-          </li>
+
+        <%= render "compromised_instructions" do %>
           <li>Look out for unexpected changes to your gems on RubyGems.org</li>
-          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
-        </ol>
+        <% end %>
+
+        <p>
+          <em>
+            To stop receiving these messages, update your <%= link_to("email notification settings", notifier_url) %>.
+          </em>
+        </p>
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/app/views/mailer/owners_update.html.erb
+++ b/app/views/mailer/owners_update.html.erb
@@ -1,0 +1,44 @@
+<% @title = t(".title") %>
+<% @sub_title = t(".subtitle", user_handle: @user.handle) %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <br>
+        <p>
+          <%= @owner.id == @user.id ? I18n.t("mailer.owners_update.body_self", status: @status, gem: @rubygem.name) : I18n.t("mailer.owners_update.body_others", status: @status, gem: @rubygem.name, owner_handle: @owner.handle) %>
+        </p>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+        <p>
+          Update your notification settings if you want to stop receiving owner change emails
+        </p>
+        <p>If this change is expected, you do not need to take further action.</p>
+        <p>
+          <strong>Only if this change is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+        <ol>
+          <li>If you suspect your account was compromised:
+            <ul>
+              <li><%= link_to("Change your password", new_password_url) %></li>
+              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
+              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
+              <li><%= link_to("Renable email notification for your gem", notifier_url) %></li>
+            </ul>
+          </li>
+          <li>Look out for unexpected changes to your gems on RubyGems.org</li>
+          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
+        </ol>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>

--- a/app/views/mailer/ownership_confirmation.html.erb
+++ b/app/views/mailer/ownership_confirmation.html.erb
@@ -29,7 +29,7 @@
                       </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= confirm_owners_url(token: @ownership.token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
+                          <a href=<%= confirm_rubygem_owners_url(@rubygem, token: @ownership.token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/mailer/ownership_confirmation.html.erb
+++ b/app/views/mailer/ownership_confirmation.html.erb
@@ -1,0 +1,59 @@
+<% @title = t(".title") %>
+<% @sub_title = t(".subtitle", handle: @user.handle) %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        Hi <%= @user.handle %>. <%= t("mailer.ownership_confirmation.body_html", gem: @rubygem.name) %><br />
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <!-- Button -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center">
+            <table width="210" border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td align="center" bgcolor="#e9573f">
+                  <table border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+                      </td>
+                      <td bgcolor="#e9573f">
+                        <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                          <a href=<%= confirm_owners_url(token: @ownership.token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
+                        </div>
+                      </td>
+                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+      <!-- END Button -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        <%= t(".link_expiration_explanation") %><br />
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -8,12 +8,12 @@
         <h4><%= ownership.rubygem.name %></h4>
         <p>
           <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}]", :on, ownership.notifier? %>
+            <%= radio_button_tag "ownerships[#{ownership.id}]", :on, ownership.push_notifier? %>
             <%= t('.on') %> <em>(<%= t('.recommended') %>)</em>
           <% end %>
           <br>
           <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}]", :off, !ownership.notifier? %>
+            <%= radio_button_tag "ownerships[#{ownership.id}]", :off, !ownership.push_notifier? %>
             <%= t('.off') %>
           <% end %>
         </p>

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -3,17 +3,31 @@
 <% if @ownerships.any? %>
   <div class="t-body">
     <%= form_tag notifier_path, method: :put do %>
-      <p><%= t('.info') %></p>
+
       <% @ownerships.each do |ownership| %>
-        <h4><%= ownership.rubygem.name %></h4>
+        <h2><%= ownership.rubygem.name %></h2>
+        <p><%= t('.push_info') %></p>
         <p>
           <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}]", :on, ownership.push_notifier? %>
+            <%= radio_button_tag "ownerships[#{ownership.id}][push]", :on, ownership.push_notifier? %>
             <%= t('.on') %> <em>(<%= t('.recommended') %>)</em>
           <% end %>
           <br>
           <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}]", :off, !ownership.push_notifier? %>
+            <%= radio_button_tag "ownerships[#{ownership.id}][push]", :off, !ownership.push_notifier? %>
+            <%= t('.off') %>
+          <% end %>
+        </p>
+
+        <p><%= t('.owner_info') %></p>
+        <p>
+          <%= label_tag do %>
+            <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :on, ownership.owner_notifier? %>
+            <%= t('.on') %> <em>(<%= t('.recommended') %>)</em>
+          <% end %>
+          <br>
+          <%= label_tag do %>
+            <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :off, !ownership.owner_notifier? %>
             <%= t('.off') %>
           <% end %>
         </p>

--- a/app/views/owners/_owner_details.html.erb
+++ b/app/views/owners/_owner_details.html.erb
@@ -1,0 +1,15 @@
+<div class="tooltip tooltip-effect">
+  <div class="tooltip-item"><%= link_to(owner.name, profile_path(owner), class: "owner_profile") %></div>
+  <div class="tooltip-content">
+    <%= gravatar(160, owner.handle, owner) %>
+    <div class="tooltip-text">
+      <span class="tooltip-title"><%= owner.handle %></span>
+      <br>
+      <span class="tooltip-subtitle"><%= owner.name %></span>
+      <hr>
+      <div class="tooltip-mfa">MFA: <%= mfa_status(ownership.user) %></div>
+      <div class="tooltip-added-by">ADDED BY: <%= ownership.authorizer.name %></div>
+      <div class="tooltip-added-on">ADDED ON: <%= nice_date_for(ownership.confirmed_at) if ownership.confirmed? %></div>
+    </div>
+  </div>
+</div>

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -24,7 +24,7 @@
   <% @ownerships.each do |ownership| %>
     <tr class="owners__row">
       <td class="owners__cell" data-title="Name">
-        <%= ownership.user.name %>
+        <%= link_to(ownership.user.name, profile_path(ownership.user), class: "owner_profile") %>
       </td>
       <td class="owners__cell" data-title="MFA">
         <%= ownership.user.mfa_level == "disabled" ? "✗" : "✔" %>

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -21,130 +21,27 @@
     </th>
   </tr>
 
-  <tr class="owners__row">
-    <td class="owners__cell" data-title="Name">
-      Luke Peters
-    </td>
-    <td class="owners__cell" data-title="MFA">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Confirmed">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Added On">
-      <%= nice_date_for(Time.now) %>
-    </td>
-    <td class="owners__cell" data-title="Added By">
-      Joseph Smith
-    </td>
-    <td class="owners__cell" data-title="Action">
-      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
-    </td>
-  </tr>
-
-  <tr class="owners__row">
-    <td class="owners__cell" data-title="Name">
-      Luke Peters
-    </td>
-    <td class="owners__cell" data-title="MFA">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Confirmed">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Added On">
-      <%= nice_date_for(Time.now) %>
-    </td>
-    <td class="owners__cell" data-title="Added By">
-      Joseph Smith
-    </td>
-    <td class="owners__cell" data-title="Action">
-      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
-    </td>
-  </tr>
-
-  <tr class="owners__row">
-    <td class="owners__cell" data-title="Name">
-      Luke Peters
-    </td>
-    <td class="owners__cell" data-title="MFA">
-
-    </td>
-    <td class="owners__cell" data-title="Confirmed">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Added On">
-      <%= nice_date_for(Time.now) %>
-    </td>
-    <td class="owners__cell" data-title="Added By">
-      Joseph Smith
-    </td>
-    <td class="owners__cell" data-title="Action">
-      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
-    </td>
-  </tr>
-
-  <tr class="owners__row">
-    <td class="owners__cell" data-title="Name">
-      Joseph Smith
-    </td>
-    <td class="owners__cell" data-title="MFA">
-
-    </td>
-    <td class="owners__cell" data-title="Confirmed">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Added On">
-      <%= nice_date_for(Time.now) %>
-    </td>
-    <td class="owners__cell" data-title="Added By">
-      Original Author
-    </td>
-    <td class="owners__cell" data-title="Action">
-      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
-    </td>
-  </tr>
-
-  <tr class="owners__row">
-    <td class="owners__cell" data-title="Name">
-      Maxwell Johnson
-    </td>
-    <td class="owners__cell" data-title="MFA">
-      ✔
-    </td>
-    <td class="owners__cell" data-title="Confirmed">
-
-    </td>
-    <td class="owners__cell" data-title="Added On">
-      <%= nice_date_for(Time.now) %>
-    </td>
-    <td class="owners__cell" data-title="Added By">
-      Maxwell Johnson
-    </td>
-    <td class="owners__cell" data-title="Action">
-      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
-    </td>
-  </tr>
-
-  <tr class="owners__row">
-    <td class="owners__cell" data-title="Name">
-      Harry Harrison
-    </td>
-    <td class="owners__cell" data-title="MFA">
-
-    </td>
-    <td class="owners__cell" data-title="Confirmed">
-
-    </td>
-    <td class="owners__cell" data-title="Added On">
-      <%= nice_date_for(Time.now) %>
-    </td>
-    <td class="owners__cell" data-title="Added By">
-      Maxwell Johnson
-    </td>
-    <td class="owners__cell" data-title="Action">
-      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
-    </td>
-  </tr>
+  <% @ownerships.each do |ownership| %>
+    <tr class="owners__row">
+      <td class="owners__cell" data-title="Name">
+        <%= ownership.user.name %>
+      </td>
+      <td class="owners__cell" data-title="MFA">
+        <%= ownership.user.mfa_level == "disabled" ? "✗" : "✔" %>
+      </td>
+      <td class="owners__cell" data-title="Confirmed">
+        <%= ownership.confirmed? ? "✔" : "✗" %>
+      </td>
+      <td class="owners__cell" data-title="Added On">
+        <%= nice_date_for(ownership.confirmed_at) if ownership.confirmed? %>
+      </td>
+      <td class="owners__cell" data-title="Added By">
+        <%= ownership.authorizer.name %>
+      </td>
+      <td class="owners__cell" data-title="Action">
+        <%= button_to "Remove", rubygem_owner_path(@rubygem, ownership), :method => 'delete', :class => 'remove__owners__button' %>
+      </td>
+    </tr>
+  <% end %>
   </tbody>
 </table>

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -1,0 +1,150 @@
+<table class="owners__table">
+  <tbody class="owners__tbody">
+  <tr class="owners__row owners__header">
+    <th class="owners__cell">
+      NAME
+    </th>
+    <th class="owners__cell">
+      MFA
+    </th>
+    <th class="owners__cell">
+      CONFIRMED
+    </th>
+    <th class="owners__cell">
+      ADDED ON
+    </th>
+    <th class="owners__cell">
+      ADDED BY
+    </th>
+    <th class="owners__cell">
+      ACTION
+    </th>
+  </tr>
+
+  <tr class="owners__row">
+    <td class="owners__cell" data-title="Name">
+      Luke Peters
+    </td>
+    <td class="owners__cell" data-title="MFA">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Confirmed">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Added On">
+      <%= nice_date_for(Time.now) %>
+    </td>
+    <td class="owners__cell" data-title="Added By">
+      Joseph Smith
+    </td>
+    <td class="owners__cell" data-title="Action">
+      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
+    </td>
+  </tr>
+
+  <tr class="owners__row">
+    <td class="owners__cell" data-title="Name">
+      Luke Peters
+    </td>
+    <td class="owners__cell" data-title="MFA">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Confirmed">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Added On">
+      <%= nice_date_for(Time.now) %>
+    </td>
+    <td class="owners__cell" data-title="Added By">
+      Joseph Smith
+    </td>
+    <td class="owners__cell" data-title="Action">
+      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
+    </td>
+  </tr>
+
+  <tr class="owners__row">
+    <td class="owners__cell" data-title="Name">
+      Luke Peters
+    </td>
+    <td class="owners__cell" data-title="MFA">
+
+    </td>
+    <td class="owners__cell" data-title="Confirmed">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Added On">
+      <%= nice_date_for(Time.now) %>
+    </td>
+    <td class="owners__cell" data-title="Added By">
+      Joseph Smith
+    </td>
+    <td class="owners__cell" data-title="Action">
+      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
+    </td>
+  </tr>
+
+  <tr class="owners__row">
+    <td class="owners__cell" data-title="Name">
+      Joseph Smith
+    </td>
+    <td class="owners__cell" data-title="MFA">
+
+    </td>
+    <td class="owners__cell" data-title="Confirmed">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Added On">
+      <%= nice_date_for(Time.now) %>
+    </td>
+    <td class="owners__cell" data-title="Added By">
+      Original Author
+    </td>
+    <td class="owners__cell" data-title="Action">
+      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
+    </td>
+  </tr>
+
+  <tr class="owners__row">
+    <td class="owners__cell" data-title="Name">
+      Maxwell Johnson
+    </td>
+    <td class="owners__cell" data-title="MFA">
+      ✔
+    </td>
+    <td class="owners__cell" data-title="Confirmed">
+
+    </td>
+    <td class="owners__cell" data-title="Added On">
+      <%= nice_date_for(Time.now) %>
+    </td>
+    <td class="owners__cell" data-title="Added By">
+      Maxwell Johnson
+    </td>
+    <td class="owners__cell" data-title="Action">
+      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
+    </td>
+  </tr>
+
+  <tr class="owners__row">
+    <td class="owners__cell" data-title="Name">
+      Harry Harrison
+    </td>
+    <td class="owners__cell" data-title="MFA">
+
+    </td>
+    <td class="owners__cell" data-title="Confirmed">
+
+    </td>
+    <td class="owners__cell" data-title="Added On">
+      <%= nice_date_for(Time.now) %>
+    </td>
+    <td class="owners__cell" data-title="Added By">
+      Maxwell Johnson
+    </td>
+    <td class="owners__cell" data-title="Action">
+      <%= button_to "Remove", rubygem_path(@rubygem), :method => 'get', :class => 'remove__owners__button' %>
+    </td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -2,22 +2,22 @@
   <tbody class="owners__tbody">
   <tr class="owners__row owners__header">
     <th class="owners__cell">
-      NAME
+      <%= t('owners.index.name') %>
     </th>
     <th class="owners__cell">
-      MFA
+      <%= t('owners.index.mfa') %>
     </th>
     <th class="owners__cell">
-      CONFIRMED
+      <%= t('owners.index.confirmed') %>
     </th>
     <th class="owners__cell">
-      ADDED ON
+      <%= t('owners.index.added_on') %>
     </th>
     <th class="owners__cell">
-      ADDED BY
+      <%= t('owners.index.added_by') %>
     </th>
     <th class="owners__cell">
-      ACTION
+      <%= t('owners.index.action') %>
     </th>
   </tr>
 

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -5,16 +5,7 @@
       <%= t('owners.index.name') %>
     </th>
     <th class="owners__cell">
-      <%= t('owners.index.mfa') %>
-    </th>
-    <th class="owners__cell">
       <%= t('owners.index.confirmed') %>
-    </th>
-    <th class="owners__cell">
-      <%= t('owners.index.added_on') %>
-    </th>
-    <th class="owners__cell">
-      <%= t('owners.index.added_by') %>
     </th>
     <th class="owners__cell">
       <%= t('owners.index.action') %>
@@ -24,22 +15,15 @@
   <% @ownerships.each do |ownership| %>
     <tr class="owners__row">
       <td class="owners__cell" data-title="Name">
-        <%= link_to(ownership.user.name, profile_path(ownership.user), class: "owner_profile") %>
-      </td>
-      <td class="owners__cell" data-title="MFA">
-        <%= ownership.user.mfa_level == "disabled" ? "✗" : "✔" %>
+        <%= render "owner_details", ownership: ownership, owner: ownership.user %>
       </td>
       <td class="owners__cell" data-title="Confirmed">
-        <%= ownership.confirmed? ? "✔" : "✗" %>
-      </td>
-      <td class="owners__cell" data-title="Added On">
-        <%= nice_date_for(ownership.confirmed_at) if ownership.confirmed? %>
-      </td>
-      <td class="owners__cell" data-title="Added By">
-        <%= ownership.authorizer.name %>
+        <%= confirmation_status(ownership) %>
       </td>
       <td class="owners__cell" data-title="Action">
-        <%= button_to "Remove", rubygem_owner_path(@rubygem, ownership), :method => 'delete', :class => 'remove__owners__button' %>
+        <%= button_to rubygem_owner_path(@rubygem, ownership), :method => "delete", :class => "owners__btn--remove", data: {confirm: "#{ownership.user.name} will be removed as owner. Are you sure?"} do %>
+          <span data-icon="✗ ">Remove</span>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/owners/index.html.erb
+++ b/app/views/owners/index.html.erb
@@ -22,8 +22,7 @@
       <div class="t-body">
         <h2>ADD OWNER</h2>
       </div>
-      <br>
-      <%= form_for rubygems_path, method: :get do |form| %>
+      <%= form_for rubygem_owners_path, method: :post do |form| %>
         <%= text_field_tag :owner, nil, placeholder: "Name of user", class: "add_owner__field" %>
         <%= label_tag :owner do %>
           <span class="t-hidden">Name of user</span>

--- a/app/views/owners/index.html.erb
+++ b/app/views/owners/index.html.erb
@@ -1,0 +1,37 @@
+<% @title = @rubygem.name %>
+
+<% content_for :head do %>
+  <meta name="robots" content="noindex"/>
+<% end %>
+
+
+<div class="row">
+  <div class="column l-column">
+
+    <div class="owners__navigation">
+      <%= link_to "← Back", rubygem_path(@rubygem), class: "owners__back__navigation" %>
+    </div>
+
+    <div class="owners__wrapper">
+      <%= render 'owners_table' %>
+    </div>
+  </div>
+
+  <div class="column r-column">
+    <div class="right_wrapper">
+      <div class="t-body">
+        <h2>ADD OWNER</h2>
+      </div>
+      <br>
+      <%= form_for rubygems_path, method: :get do |form| %>
+        <%= text_field_tag :owner, nil, placeholder: "Name of user", class: "add_owner__field" %>
+        <%= label_tag :owner do %>
+          <span class="t-hidden">Name of user</span>
+        <% end %>
+        <div class="submit_field">
+          <%= form.submit 'Add Owner', :data => {:disable_with => t('form_disable_with')}, :class => 'add__owners__button' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/owners/index.html.erb
+++ b/app/views/owners/index.html.erb
@@ -13,22 +13,22 @@
     </div>
 
     <div class="owners__wrapper">
-      <%= render 'owners_table' %>
+      <%= render "owners_table" %>
     </div>
   </div>
 
   <div class="column r-column">
     <div class="right_wrapper">
       <div class="t-body">
-        <h2>ADD OWNER</h2>
+        <h2><%= t('owners.index.add_owner') %></h2>
       </div>
       <%= form_for rubygem_owners_path, method: :post do |form| %>
-        <%= text_field_tag :owner, nil, placeholder: "Name of user", class: "add_owner__field" %>
+        <%= text_field_tag :owner, nil, placeholder: "Email / Handle", class: "add_owner__field" %>
         <%= label_tag :owner do %>
           <span class="t-hidden">Name of user</span>
         <% end %>
         <div class="submit_field">
-          <%= form.submit 'Add Owner', :data => {:disable_with => t('form_disable_with')}, :class => 'add__owners__button' %>
+          <%= form.submit "Add Owner", :data => {:disable_with => t('form_disable_with')}, :class => "add__owners__button" %>
         </div>
       <% end %>
     </div>

--- a/app/views/owners/index.html.erb
+++ b/app/views/owners/index.html.erb
@@ -4,12 +4,15 @@
   <meta name="robots" content="noindex"/>
 <% end %>
 
-
-<div class="row">
-  <div class="column l-column">
+<div class="l-overflow">
+  <div class="l-colspan--l colspan--l--has-border">
 
     <div class="owners__navigation">
-      <%= link_to "← Back", rubygem_path(@rubygem), class: "owners__back__navigation" %>
+      <%= link_to "← Back", rubygem_path(@rubygem), class: "owners__back_navigation" %>
+    </div>
+
+    <div class="owners__intro">
+      Use this page to control which Rubygems users can help you to manage <%= @rubygem.name %>
     </div>
 
     <div class="owners__wrapper">
@@ -17,20 +20,18 @@
     </div>
   </div>
 
-  <div class="column r-column">
-    <div class="right_wrapper">
-      <div class="t-body">
-        <h2><%= t('owners.index.add_owner') %></h2>
-      </div>
-      <%= form_for rubygem_owners_path, method: :post do |form| %>
-        <%= text_field_tag :owner, nil, placeholder: "Email / Handle", class: "add_owner__field" %>
-        <%= label_tag :owner do %>
-          <span class="t-hidden">Name of user</span>
-        <% end %>
-        <div class="submit_field">
-          <%= form.submit "Add Owner", :data => {:disable_with => t('form_disable_with')}, :class => "add__owners__button" %>
-        </div>
-      <% end %>
+  <div class="gem__aside l-col--r--pad">
+    <div class="t-body">
+      <h2><%= t('owners.index.add_owner') %></h2>
     </div>
+    <%= form_for :ownership, url: rubygem_owners_path, method: :post, html: { class: "new_ownership", id: "new_ownership" } do |form| %>
+      <div class="text_field">
+        <%= form.label :email, "Email/Handle", :class => "form__label" %>
+        <%= form.text_field :email, :class => "form__input", required: true %>
+      </div>
+      <div class="submit_field">
+        <%= form.submit "Add Owner", :data => {:disable_with => t('form_disable_with')}, :class => "form__submit" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -71,5 +71,6 @@
     <%= atom_link(@rubygem) %>
     <%= report_abuse_link(@rubygem) %>
     <%= reverse_dependencies_link(@rubygem) %>
+    <%= ownership_link(@rubygem) %>
   </div>
 </div>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -71,6 +71,7 @@
     <%= atom_link(@rubygem) %>
     <%= report_abuse_link(@rubygem) %>
     <%= reverse_dependencies_link(@rubygem) %>
-    <%= ownership_link(@rubygem) %>
+    <%= ownership_link(@rubygem) if current_user && @rubygem.owned_by?(current_user) %>
+    <%= resend_owner_confirmation_link(@rubygem) if current_user&.unconfirmed_ownership(@rubygem) %>
   </div>
 </div>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -72,6 +72,6 @@
     <%= report_abuse_link(@rubygem) %>
     <%= reverse_dependencies_link(@rubygem) %>
     <%= ownership_link(@rubygem) if current_user && @rubygem.owned_by?(current_user) %>
-    <%= resend_owner_confirmation_link(@rubygem) if current_user&.unconfirmed_ownership(@rubygem) %>
+    <%= resend_owner_confirmation_link(@rubygem) if @rubygem.unconfirmed_ownership?(current_user) %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,6 +68,7 @@ module Gemcutter
   NEWS_PER_PAGE = 10
   MAX_PAGES = 1000
   MFA_KEY_EXPIRY = 30.minutes
+  OWNERSHIP_TOKEN_EXPIRES_AFTER = 48.hours
   POPULAR_DAYS_LIMIT = 70.days
   PROTOCOL = config["protocol"]
   REMEMBER_FOR = 2.weeks

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -140,24 +140,33 @@ de:
     gem_pushed:
       subject:
       title:
-    gem_yanked:
-      subject:
-      title:
-    reset_api_key:
-      subject:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
-      subject_self:
-      subject_others:
-      body_self:
-      body_others:
+    gem_yanked:
+      subject:
+      title:
+    reset_api_key:
+      subject:
       title:
       subtitle:
+    owner_added:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title:
@@ -395,4 +404,12 @@ de:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -145,6 +145,17 @@ de:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -216,12 +227,13 @@ de:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +392,7 @@ de:
         one: Zeige <b>1</b> %{model}
         other: Zeige <b>alle&nbsp;%{count}</b> %{model}
         zero: Kein %{model} gefunden
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
   update: Update
   try_again: Something went wrong. Please try again.
   advanced_search: Advanced Search
+  token_expired: The confirmation token has expired. Please try resending the token
   activerecord:
     attributes:
       linkset:
@@ -237,14 +238,17 @@ en:
     update:
       success: You have successfully updated your email notification settings.
     show:
-      info: To aid detection of unauthorized gem changes, we email you each time a new version of a
-        gem you own is pushed or yanked. By receiving and reading these emails, you help protect the Ruby
+      push_info: To aid detection of unauthorized gem changes, we email you each time a new version of a
+        gem you own is pushed. By receiving and reading these emails, you help protect the Ruby
         ecosystem.
       on: On
       off: Off
       recommended: recommended
       title: Email notifications
       update: Update
+      owner_info: To aid detection of unauthorized ownership changes, we email you each time a new owner is
+        added or removed to the gem. By receiving and reading these emails, you help protect the Ruby
+        ecosystem.
   owners:
     confirm:
       confirmed_email: You are added as an owner to %{gem} gem!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,13 +162,20 @@ en:
       subtitle: Hi %{handle}!
       body_html: You were added as an owner for <strong>%{gem}</strong> gem on RubyGems.org. Please click on the link below to confirm your ownership.
       link_expiration_explanation: Please keep in mind that this link is only valid for 48 hours.
-    owners_update:
-      subject_self: You were %{status} as an owner to %{gem} gem
-      subject_others: User %{owner_handle} was %{status} as an owner to %{gem} gem
-      title: OWNERS UPDATED
+    owner_added:
+      subject_self: You were added as an owner to %{gem} gem
+      subject_others: User %{owner_handle} was added as an owner to %{gem} gem
+      title: OWNER ADDED
       subtitle: Hi %{user_handle}!
-      body_self: You were %{status} as an owner for <strong>%{gem}</strong> gem on RubyGems.org.
-      body_others: User %{owner_handle} was %{status} as an owner for %{gem} gem on RubyGems.org.
+      body_self: You were added as an owner for <strong>%{gem}</strong> gem on RubyGems.org.
+      body_others: User %{owner_handle} was added as an owner for %{gem} gem on RubyGems.org.
+    owner_removed:
+      subject_self: You were removed as an owner to %{gem} gem
+      subject_others: User %{owner_handle} was removed as an owner to %{gem} gem
+      title: OWNER REMOVED
+      subtitle: Hi %{user_handle}!
+      body_self: You were removed as an owner for <strong>%{gem}</strong> gem on RubyGems.org.
+      body_others: User %{owner_handle} was removed as an owner for %{gem} gem on RubyGems.org.
   news:
     show:
       title: New Releases — All Gems
@@ -239,7 +246,7 @@ en:
       success: You have successfully updated your email notification settings.
     show:
       push_info: To aid detection of unauthorized gem changes, we email you each time a new version of a
-        gem you own is pushed. By receiving and reading these emails, you help protect the Ruby
+        gem you own is pushed or yanked. By receiving and reading these emails, you help protect the Ruby
         ecosystem.
       on: On
       off: Off
@@ -252,6 +259,14 @@ en:
   owners:
     confirm:
       confirmed_email: You are added as an owner to %{gem} gem!
+    index:
+      add_owner: "ADD OWNER"
+      name: "NAME"
+      mfa: "MFA"
+      confirmed: "CONFIRMED"
+      added_on: "ADDED ON"
+      added_by: "ADDED BY"
+      action: "ACTION"
   profiles:
     edit:
       change_avatar: Change Avatar

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,19 @@ en:
       subject: RubyGems.org API key was reset
       title: API KEY RESET
       subtitle: Hi %{handle}
+    ownership_confirmation:
+      subject: Please confirm the ownership of %{gem} gem on RubyGems.org
+      title: OWNERSHIP CONFIRMATION
+      subtitle: Hi %{handle}!
+      body_html: You were added as an owner for <strong>%{gem}</strong> gem on RubyGems.org. Please click on the link below to confirm your ownership.
+      link_expiration_explanation: Please keep in mind that this link is only valid for 48 hours.
+    owners_update:
+      subject_self: You were %{status} as an owner to %{gem} gem
+      subject_others: User %{owner_handle} was %{status} as an owner to %{gem} gem
+      title: OWNERS UPDATED
+      subtitle: Hi %{user_handle}!
+      body_self: You were %{status} as an owner for <strong>%{gem}</strong> gem on RubyGems.org.
+      body_others: User %{owner_handle} was %{status} as an owner for %{gem} gem on RubyGems.org.
   news:
     show:
       title: New Releases — All Gems
@@ -232,6 +245,9 @@ en:
       recommended: recommended
       title: Email notifications
       update: Update
+  owners:
+    confirm:
+      confirmed_email: You are added as an owner to %{gem} gem!
   profiles:
     edit:
       change_avatar: Change Avatar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -153,6 +153,17 @@ es:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -224,7 +235,7 @@ es:
     update:
       success: Has actualizado exitosamente la configuración de tus notificaciones por email.
     show:
-      info: Para facilitar la detección de cambios no autorizados en tus gemas, te enviamos un email
+      push_info: Para facilitar la detección de cambios no autorizados en tus gemas, te enviamos un email
         cada vez que una nueva versión es subida a RubyGems.org. Recibiendo y leyendo estos emails
         ayudas a proteger el ecosistema de Ruby.
       on: Activado
@@ -232,6 +243,7 @@ es:
       recommended: recomendado
       title: Notificación de email
       update: Actualizar
+      owner_info: ""
   profiles:
     edit:
       change_avatar:
@@ -390,3 +402,7 @@ es:
         one: Mostrando <b>1</b> %{model}
         other: Mostrando <b>todos los&nbsp;%{count}</b> %{model}
         zero: No se encontró ningún %{model}
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -153,19 +153,28 @@ es:
       title:
     reset_api_key:
       subject:
+      title:
+      subtitle:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
       subject_self:
       subject_others:
-      body_self:
-      body_others:
       title:
       subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title: Nuevos lanzamientos — Todas las Gemas
@@ -243,7 +252,7 @@ es:
       recommended: recomendado
       title: Notificación de email
       update: Actualizar
-      owner_info: ""
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -405,4 +414,12 @@ es:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -145,19 +145,28 @@ fr:
       title:
     reset_api_key:
       subject:
+      title:
+      subtitle:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
       subject_self:
       subject_others:
-      body_self:
-      body_others:
       title:
       subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems
@@ -395,4 +404,12 @@ fr:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -145,6 +145,17 @@ fr:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -216,12 +227,13 @@ fr:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +392,7 @@ fr:
         one: "<b>1</b> %{model} affiché"
         other: Les <b>%{count}</b> %{model} affichés
         zero: Aucun %{model} trouvé
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -145,6 +145,17 @@ ja:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -216,12 +227,13 @@ ja:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +392,7 @@ ja:
         one: <b>全1件</b>の%{model}を表示中
         other: <b>全 %{count}件</b>の%{model}を表示中
         zero: '%{model}は見つかりませんでした'
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -145,19 +145,28 @@ ja:
       title:
     reset_api_key:
       subject:
+      title:
+      subtitle:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
       subject_self:
       subject_others:
-      body_self:
-      body_others:
       title:
       subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title: 新しくリリースされたGem
@@ -395,4 +404,12 @@ ja:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -145,19 +145,28 @@ nl:
       title:
     reset_api_key:
       subject:
+      title:
+      subtitle:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
       subject_self:
       subject_others:
-      body_self:
-      body_others:
       title:
       subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title:
@@ -395,4 +404,12 @@ nl:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -145,6 +145,17 @@ nl:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -216,12 +227,13 @@ nl:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +392,7 @@ nl:
         one:
         other:
         zero:
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -145,19 +145,28 @@ pt-BR:
       title:
     reset_api_key:
       subject:
+      title:
+      subtitle:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
       subject_self:
       subject_others:
-      body_self:
-      body_others:
       title:
       subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title: Novos Releases - Todas as Gems
@@ -395,4 +404,12 @@ pt-BR:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -145,6 +145,17 @@ pt-BR:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -216,12 +227,13 @@ pt-BR:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +392,7 @@ pt-BR:
         one:
         other:
         zero:
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -145,6 +145,17 @@ zh-CN:
       title:
     reset_api_key:
       subject:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      body_self:
+      body_others:
       title:
       subtitle:
   news:
@@ -216,12 +227,13 @@ zh-CN:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +392,7 @@ zh-CN:
         one: 显示 <b>1</b> %{model}
         other: 显示 <b>所有 %{count}</b> %{model}
         zero: 暂时没有 %{model}
+  owners:
+    confirm:
+      confirmed_email:
+  token_expired: ""

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -145,19 +145,28 @@ zh-CN:
       title:
     reset_api_key:
       subject:
+      title:
+      subtitle:
     ownership_confirmation:
       subject:
       title:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
       subject_self:
       subject_others:
-      body_self:
-      body_others:
       title:
       subtitle:
+      body_self:
+      body_others:
+    owner_removed:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title: 全部新发布 Gems
@@ -395,4 +404,12 @@ zh-CN:
   owners:
     confirm:
       confirmed_email:
-  token_expired: ""
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
+  token_expired:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -147,6 +147,19 @@ zh-TW:
       subject:
       title:
       subtitle:
+    ownership_confirmation:
+      subject:
+      title:
+      subtitle:
+      body_html:
+      link_expiration_explanation:
+    owners_update:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
   news:
     show:
       title: 最新發佈
@@ -216,12 +229,16 @@ zh-TW:
     update:
       success:
     show:
-      info:
+      push_info:
       on:
       off:
       recommended:
       title:
       update:
+      owner_info:
+  owners:
+    confirm:
+      confirmed_email:
   profiles:
     edit:
       change_avatar:
@@ -380,3 +397,4 @@ zh-TW:
         one: 顯示 <b>1</b> %{model}
         other: 顯示 <b>所有 %{count}</b> %{model}
         zero: 找不到 %{model}
+  token_expired: ""

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -153,7 +153,14 @@ zh-TW:
       subtitle:
       body_html:
       link_expiration_explanation:
-    owners_update:
+    owner_added:
+      subject_self:
+      subject_others:
+      title:
+      subtitle:
+      body_self:
+      body_others:
+    owner_removed:
       subject_self:
       subject_others:
       title:
@@ -239,6 +246,14 @@ zh-TW:
   owners:
     confirm:
       confirmed_email:
+    index:
+      add_owner:
+      name:
+      mfa:
+      confirmed:
+      added_on:
+      added_by:
+      action:
   profiles:
     edit:
       change_avatar:
@@ -397,4 +412,4 @@ zh-TW:
         one: 顯示 <b>1</b> %{model}
         other: 顯示 <b>所有 %{count}</b> %{model}
         zero: 找不到 %{model}
-  token_expired: ""
+  token_expired:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,9 +118,6 @@ Rails.application.routes.draw do
     scope path: 'gems/:rubygem_id' do
       put 'migrate'
       post 'migrate'
-      get 'owners(.:format)'
-      post 'owners(.:format)'
-      delete 'owners(.:format)'
     end
   end
 
@@ -158,6 +155,10 @@ Rails.application.routes.draw do
         get '/dependencies', to: 'dependencies#show', constraints: { format: /json|html/ }
       end
       resources :reverse_dependencies, only: %i[index]
+      resources :owners, only: %i[index destroy create] do
+        get 'confirm/:token', to: 'owners#confirm', as: :confirm, on: :collection
+        get 'resend_confirmation', to: 'owners#resend_confirmation', as: :resend_confirmation, on: :collection
+      end
     end
 
     ################################################################################
@@ -178,10 +179,6 @@ Rails.application.routes.draw do
       resource :password, only: %i[create edit update] do
         post 'mfa_edit', to: 'passwords#mfa_edit', as: :mfa_edit
       end
-    end
-
-    resources :owners, only: %i[] do
-      get 'confirm/:token', to: 'owners#confirm', as: :confirm, on: :collection
     end
 
     get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,6 +180,10 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :owners, only: %i[] do
+      get 'confirm/:token', to: 'owners#confirm', as: :confirm, on: :collection
+    end
+
     get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 

--- a/db/migrate/20200513101546_rename_ownership_notifier.rb
+++ b/db/migrate/20200513101546_rename_ownership_notifier.rb
@@ -1,0 +1,5 @@
+class RenameOwnershipNotifier < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :ownerships, :notifier, :push_notifier
+  end
+end

--- a/db/migrate/20200516071636_add_ownership_confirmation.rb
+++ b/db/migrate/20200516071636_add_ownership_confirmation.rb
@@ -1,7 +1,8 @@
 class AddOwnershipConfirmation < ActiveRecord::Migration[6.0]
   def change
-    add_column :ownerships, :confirmed, :boolean, default: false, null: false
+    add_column :ownerships, :confirmed_at, :datetime
     add_column :ownerships, :token_expires_at, :datetime
     add_column :ownerships, :owner_notifier, :boolean, default: true, null: false
+    add_column :ownerships, :authorizer_id, :integer
   end
 end

--- a/db/migrate/20200516071636_add_ownership_confirmation.rb
+++ b/db/migrate/20200516071636_add_ownership_confirmation.rb
@@ -1,0 +1,7 @@
+class AddOwnershipConfirmation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ownerships, :confirmed, :boolean, default: false, null: false
+    add_column :ownerships, :token_expires_at, :datetime
+    add_column :ownerships, :owner_notifier, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2020_05_16_071636) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "slug"
+    t.boolean "indexed", default: false, null: false
     t.index "upper((name)::text) varchar_pattern_ops", name: "index_rubygems_upcase"
     t.index ["indexed"], name: "index_rubygems_on_indexed"
     t.index ["name"], name: "index_rubygems_on_name", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_234114) do
+ActiveRecord::Schema.define(version: 2020_05_16_071636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -47,13 +47,13 @@ ActiveRecord::Schema.define(version: 2020_05_08_234114) do
   end
 
   create_table "dependencies", id: :serial, force: :cascade do |t|
-    t.string "requirements"
+    t.string "requirements", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "rubygem_id"
     t.integer "version_id"
-    t.string "scope"
-    t.string "unresolved_name"
+    t.string "scope", limit: 255
+    t.string "unresolved_name", limit: 255
     t.index ["rubygem_id"], name: "index_dependencies_on_rubygem_id"
     t.index ["unresolved_name"], name: "index_dependencies_on_unresolved_name"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
@@ -76,12 +76,12 @@ ActiveRecord::Schema.define(version: 2020_05_08_234114) do
 
   create_table "linksets", id: :serial, force: :cascade do |t|
     t.integer "rubygem_id"
-    t.string "home"
-    t.string "wiki"
-    t.string "docs"
-    t.string "mail"
-    t.string "code"
-    t.string "bugs"
+    t.string "home", limit: 255
+    t.string "wiki", limit: 255
+    t.string "docs", limit: 255
+    t.string "mail", limit: 255
+    t.string "code", limit: 255
+    t.string "bugs", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["rubygem_id"], name: "index_linksets_on_rubygem_id"
@@ -104,17 +104,19 @@ ActiveRecord::Schema.define(version: 2020_05_08_234114) do
     t.string "token"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean "notifier", default: true, null: false
+    t.boolean "push_notifier", default: true, null: false
+    t.boolean "confirmed", default: false, null: false
+    t.datetime "token_expires_at"
+    t.boolean "owner_notifier", default: true, null: false
     t.index ["rubygem_id"], name: "index_ownerships_on_rubygem_id"
     t.index ["user_id"], name: "index_ownerships_on_user_id"
   end
 
   create_table "rubygems", id: :serial, force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "slug"
-    t.boolean "indexed", default: false, null: false
+    t.string "slug", limit: 255
     t.index "upper((name)::text) varchar_pattern_ops", name: "index_rubygems_upcase"
     t.index ["indexed"], name: "index_rubygems_on_indexed"
     t.index ["name"], name: "index_rubygems_on_name", unique: true
@@ -175,23 +177,23 @@ ActiveRecord::Schema.define(version: 2020_05_08_234114) do
   create_table "versions", id: :serial, force: :cascade do |t|
     t.text "authors"
     t.text "description"
-    t.string "number"
+    t.string "number", limit: 255
     t.integer "rubygem_id"
     t.datetime "built_at"
     t.datetime "updated_at"
     t.text "summary"
-    t.string "platform"
+    t.string "platform", limit: 255
     t.datetime "created_at"
     t.boolean "indexed", default: true
     t.boolean "prerelease"
     t.integer "position"
     t.boolean "latest"
-    t.string "full_name"
+    t.string "full_name", limit: 255
+    t.string "licenses", limit: 255
     t.integer "size"
-    t.string "licenses"
     t.text "requirements"
-    t.string "required_ruby_version"
-    t.string "sha256"
+    t.string "required_ruby_version", limit: 255
+    t.string "sha256", limit: 255
     t.hstore "metadata", default: {}, null: false
     t.datetime "yanked_at"
     t.string "required_rubygems_version", limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,13 +47,13 @@ ActiveRecord::Schema.define(version: 2020_05_16_071636) do
   end
 
   create_table "dependencies", id: :serial, force: :cascade do |t|
-    t.string "requirements", limit: 255
+    t.string "requirements"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "rubygem_id"
     t.integer "version_id"
-    t.string "scope", limit: 255
-    t.string "unresolved_name", limit: 255
+    t.string "scope"
+    t.string "unresolved_name"
     t.index ["rubygem_id"], name: "index_dependencies_on_rubygem_id"
     t.index ["unresolved_name"], name: "index_dependencies_on_unresolved_name"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
@@ -76,12 +76,12 @@ ActiveRecord::Schema.define(version: 2020_05_16_071636) do
 
   create_table "linksets", id: :serial, force: :cascade do |t|
     t.integer "rubygem_id"
-    t.string "home", limit: 255
-    t.string "wiki", limit: 255
-    t.string "docs", limit: 255
-    t.string "mail", limit: 255
-    t.string "code", limit: 255
-    t.string "bugs", limit: 255
+    t.string "home"
+    t.string "wiki"
+    t.string "docs"
+    t.string "mail"
+    t.string "code"
+    t.string "bugs"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["rubygem_id"], name: "index_linksets_on_rubygem_id"
@@ -105,18 +105,19 @@ ActiveRecord::Schema.define(version: 2020_05_16_071636) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "push_notifier", default: true, null: false
-    t.boolean "confirmed", default: false, null: false
+    t.datetime "confirmed_at"
     t.datetime "token_expires_at"
     t.boolean "owner_notifier", default: true, null: false
+    t.integer "authorizer_id"
     t.index ["rubygem_id"], name: "index_ownerships_on_rubygem_id"
     t.index ["user_id"], name: "index_ownerships_on_user_id"
   end
 
   create_table "rubygems", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 255
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "slug", limit: 255
+    t.string "slug"
     t.index "upper((name)::text) varchar_pattern_ops", name: "index_rubygems_upcase"
     t.index ["indexed"], name: "index_rubygems_on_indexed"
     t.index ["name"], name: "index_rubygems_on_name", unique: true
@@ -177,23 +178,23 @@ ActiveRecord::Schema.define(version: 2020_05_16_071636) do
   create_table "versions", id: :serial, force: :cascade do |t|
     t.text "authors"
     t.text "description"
-    t.string "number", limit: 255
+    t.string "number"
     t.integer "rubygem_id"
     t.datetime "built_at"
     t.datetime "updated_at"
     t.text "summary"
-    t.string "platform", limit: 255
+    t.string "platform"
     t.datetime "created_at"
     t.boolean "indexed", default: true
     t.boolean "prerelease"
     t.integer "position"
     t.boolean "latest"
-    t.string "full_name", limit: 255
-    t.string "licenses", limit: 255
+    t.string "full_name"
     t.integer "size"
+    t.string "licenses"
     t.text "requirements"
-    t.string "required_ruby_version", limit: 255
-    t.string "sha256", limit: 255
+    t.string "required_ruby_version"
+    t.string "sha256"
     t.hstore "metadata", default: {}, null: false
     t.datetime "yanked_at"
     t.string "required_rubygems_version", limit: 255

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -46,6 +46,12 @@ FactoryBot.define do
   factory :ownership do
     rubygem
     user
+    confirmed_at { Time.current }
+    authorizer { user }
+    trait :unconfirmed do
+      confirmed_at { nil }
+    end
+
   end
 
   factory :subscription do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -51,7 +51,6 @@ FactoryBot.define do
     trait :unconfirmed do
       confirmed_at { nil }
     end
-
   end
 
   factory :subscription do

--- a/test/functional/api/deprecated_controller_test.rb
+++ b/test/functional/api/deprecated_controller_test.rb
@@ -5,14 +5,6 @@ class Api::DeprecatedControllerTest < ActionController::TestCase
     route = { controller: "api/deprecated" }
     assert_recognizes(route.merge(action: "index"), path: "/api_key")
 
-    route = { controller: "api/deprecated", rubygem_id: "rails", format: "json" }
-    assert_recognizes(route.merge(action: "index"),
-      path: "/gems/rails/owners.json")
-    assert_recognizes(route.merge(action: "index"),
-      path: "/gems/rails/owners.json", method: :post)
-    assert_recognizes(route.merge(action: "index"),
-      path: "/gems/rails/owners.json", method: :delete)
-
     route = { controller: "api/deprecated", id: "rails" }
     assert_recognizes(route.merge(action: "index"), path: "/gems/rails.json")
 

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -15,7 +15,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         @rubygem = create(:rubygem)
         @user = create(:user)
         @other_user = create(:user)
-        @rubygem.ownerships.create(user: @user)
+        create(:ownership, rubygem: @rubygem, user: @user)
 
         @request.env["HTTP_AUTHORIZATION"] = @user.api_key
         get :show, params: { rubygem_id: @rubygem.to_param }, format: format
@@ -80,7 +80,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       @user = create(:user)
       @second_user = create(:user)
       @third_user = create(:user)
-      @rubygem.ownerships.create(user: @user)
+      create(:ownership, rubygem: @rubygem, user: @user)
       @request.env["HTTP_AUTHORIZATION"] = @user.api_key
     end
 
@@ -120,7 +120,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         should respond_with :success
         should "succeed to add new owner" do
-          assert @rubygem.owners.include?(@second_user)
+          assert @rubygem.owners_including_unconfirmed.include?(@second_user)
         end
       end
     end
@@ -128,12 +128,12 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     context "when mfa for UI and API is disabled" do
       should "add other user as gem owner" do
         post :create, params: { rubygem_id: @rubygem.to_param, email: @second_user.email }, format: :json
-        assert @rubygem.owners.include?(@second_user)
+        assert @rubygem.owners_including_unconfirmed.include?(@second_user)
       end
 
       should "add other user as gem owner with handle" do
         post :create, params: { rubygem_id: @rubygem.to_param, email: @third_user.handle }, format: :json
-        assert @rubygem.owners.include?(@third_user)
+        assert @rubygem.owners_including_unconfirmed.include?(@third_user)
       end
     end
   end
@@ -151,8 +151,8 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       @rubygem = create(:rubygem)
       @user = create(:user)
       @second_user = create(:user)
-      @rubygem.ownerships.create(user: @user)
-      @ownership = @rubygem.ownerships.create(user: @second_user)
+      create(:ownership, rubygem: @rubygem, user: @user)
+      @ownership = create(:ownership, rubygem: @rubygem, user: @second_user)
       @request.env["HTTP_AUTHORIZATION"] = @user.api_key
     end
 

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -30,7 +30,7 @@ class DashboardsControllerTest < ActionController::TestCase
         3.times { create(:rubygem) }
         @gems = (1..3).map do
           rubygem = create(:rubygem)
-          rubygem.ownerships.create(user: @user)
+          create(:ownership, rubygem: rubygem, user: @user)
           create(:version, rubygem: rubygem)
           rubygem
         end

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -1,0 +1,148 @@
+require "test_helper"
+
+class OwnersControllerTest < ActionController::TestCase
+
+  context "When logged in" do
+    setup do
+      @user = create(:user)
+      @rubygem = create(:rubygem)
+      create(:ownership, user: @user, rubygem: @rubygem)
+      sign_in_as(@user)
+    end
+
+    context "on GET to index" do
+      context "when user owns the gem" do
+        setup do
+          get :index, params: { rubygem_id: @rubygem.name }
+        end
+
+        should respond_with :success
+        should "render all gem owners in owners table" do
+          @rubygem.ownerships.each do |o|
+            assert page.has_content?(o.user.name)
+          end
+        end
+      end
+
+      context "when user does not own the gem" do
+        setup do
+          @other_user = create(:user)
+          sign_in_as(@other_user)
+          get :index, params: { rubygem_id: @rubygem.name }
+        end
+
+        should redirect_to("the sign in page") { sign_in_path }
+      end
+    end
+
+    context "on POST to create ownership" do
+      setup do
+        @new_owner = create(:user)
+        post :create, params: { owner: @new_owner.handle, rubygem_id: @rubygem.name }
+      end
+
+      should redirect_to("ownerships index") { rubygem_owners_path(@rubygem) }
+      should "add unconfirmed ownership record" do
+        assert @rubygem.owners_including_unconfirmed.include?(@new_owner)
+        assert_nil @rubygem.ownerships.find_by(user: @new_owner).confirmed_at
+      end
+      should "set success notice flash" do
+        expected_notice = "Owner added successfully. A confirmation mail has been sent to #{@new_owner.handle}'s email"
+        assert_equal expected_notice, flash[:notice]
+      end
+    end
+
+    context "on DELETE to owners" do
+      setup do
+        @owner = create(:user)
+        @ownership = create(:ownership, rubygem: @rubygem, user: @owner)
+      end
+
+      context "remove user as gem owner" do
+        setup do
+          delete :destroy, params: { rubygem_id: @rubygem.name, id: @ownership.id }
+        end
+        should redirect_to("ownership index") { rubygem_owners_path(@rubygem) }
+        should "remove the ownership record" do
+          refute @rubygem.owners_including_unconfirmed.include?(@owner)
+        end
+      end
+
+      context "not remove last confirmed owner" do
+        setup do
+          @ownership.destroy
+          @last_ownership = @rubygem.ownerships.last
+          delete :destroy, params: { rubygem_id: @rubygem.name, id: @last_ownership.id }
+        end
+        should redirect_to("ownership index") { rubygem_owners_path(@rubygem) }
+        should "remove the ownership record" do
+          assert @rubygem.owners_including_unconfirmed.include?(@last_ownership.user)
+        end
+        should "should flash error" do
+          assert_equal "Owner cannot be removed!", flash[:alert]
+        end
+      end
+    end
+
+    context "on GET to resend confirmation" do
+      setup do
+        @new_owner = create(:user)
+        @ownership = create(:ownership, :unconfirmed, rubygem: @rubygem, user: @new_owner)
+        sign_in_as(@new_owner)
+        get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+      end
+
+      should redirect_to("rubygem show") { rubygem_path(@rubygem) }
+      should "set success notice flash" do
+        success_flash = "A confirmation mail has been re-sent to #{@new_owner.handle}'s email"
+        assert_equal success_flash, flash[:notice]
+      end
+    end
+  end
+
+  context "When user not logged in" do
+    setup do
+      @user = create(:user)
+      @rubygem = create(:rubygem)
+    end
+
+    context "on GET to confirm" do
+      setup do
+        @ownership = create(:ownership, :unconfirmed, user: @user, rubygem: @rubygem)
+      end
+
+      context "when token has not expired" do
+        should "confirm ownership" do
+          get :confirm, params: { rubygem_id: @rubygem.name, token: @ownership.token }
+          @ownership.reload
+          assert @ownership.confirmed?
+          assert redirect_to("rubygem show") { rubygem_path(@rubygem) }
+          assert_equal flash[:notice], "You are added as an owner to #{@rubygem.name} gem!"
+        end
+      end
+
+      context "when token has expired" do
+        setup do
+          @ownership.token_expires_at = Time.current - 2.hours
+          @ownership.save
+        end
+        should "warn about invalid token" do
+          get :confirm, params: { rubygem_id: @rubygem.name, token: @ownership.token }
+          assert respond_with :success
+          assert_equal flash[:alert], "The confirmation token has expired. Please try resending the token"
+          assert @ownership.unconfirmed?
+        end
+      end
+    end
+
+    context "on GET to index" do
+      setup do
+        get :index, params: { rubygem_id: @rubygem.name }
+      end
+
+      should "redirect to sign in path" do
+        assert redirect_to("sign in") { sign_in_path }
+      end
+    end
+  end
+end

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -37,7 +37,7 @@ class OwnersControllerTest < ActionController::TestCase
     context "on POST to create ownership" do
       setup do
         @new_owner = create(:user)
-        post :create, params: { owner: @new_owner.handle, rubygem_id: @rubygem.name }
+        post :create, params: { ownership: { email: @new_owner.handle }, rubygem_id: @rubygem.name }
       end
 
       should redirect_to("ownerships index") { rubygem_owners_path(@rubygem) }

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -1,13 +1,12 @@
 require "test_helper"
 
 class OwnersControllerTest < ActionController::TestCase
-
   context "When logged in" do
     setup do
-      @user = create(:user)
+      user = create(:user)
       @rubygem = create(:rubygem)
-      create(:ownership, user: @user, rubygem: @rubygem)
-      sign_in_as(@user)
+      create(:ownership, user: user, rubygem: @rubygem)
+      sign_in_as(user)
     end
 
     context "on GET to index" do
@@ -44,7 +43,7 @@ class OwnersControllerTest < ActionController::TestCase
       should redirect_to("ownerships index") { rubygem_owners_path(@rubygem) }
       should "add unconfirmed ownership record" do
         assert @rubygem.owners_including_unconfirmed.include?(@new_owner)
-        assert_nil @rubygem.ownerships.find_by(user: @new_owner).confirmed_at
+        assert_nil @rubygem.ownerships_including_unconfirmed.find_by(user: @new_owner).confirmed_at
       end
       should "set success notice flash" do
         expected_notice = "Owner added successfully. A confirmation mail has been sent to #{@new_owner.handle}'s email"

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -256,7 +256,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem.update(created_at: 30.days.ago, updated_at: 99.days.ago)
         @owner = create(:user)
-        @rubygem.owners << @owner
+        create(:ownership, user: @owner, rubygem: @rubygem)
         get :show, params: { id: @rubygem.to_param }
       end
 

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -93,7 +93,7 @@ class VersionsControllerTest < ActionController::TestCase
   context "On GET to show with *a* yanked version" do
     setup do
       @version = create(:version, number: "1.0.1")
-      @version.rubygem.owners << create(:user, handle: "johndoe")
+      create(:ownership, rubygem: @version.rubygem, user: create(:user, handle: "johndoe"))
       create(:version, number: "1.0.2", rubygem: @version.rubygem, indexed: false)
       get :show, params: { rubygem_id: @version.rubygem.name, id: "1.0.2" }
     end

--- a/test/integration/api/v1/owner_test.rb
+++ b/test/integration/api/v1/owner_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class OwnerTest < ActionDispatch::IntegrationTest
+class Api::V1::OwnerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
     @other_user = create(:user)
@@ -16,8 +16,8 @@ class OwnerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_AUTHORIZATION" => @user.api_key }
     assert_response :success
 
-    @ownership = @other_user.ownerships.find_by(rubygem_id: @rubygem.id)
-    get confirm_rubygem_owners_url(@rubygem, token: @ownership.token.html_safe)
+    @ownership = @other_user.ownerships_including_unconfirmed.find_by(rubygem_id: @rubygem.id)
+    get confirm_rubygem_owners_url(@rubygem, token: @ownership.token)
 
     get rubygem_path(@rubygem)
     assert page.has_selector?("a[alt='#{@user.handle}']")

--- a/test/integration/api/v1/owner_test.rb
+++ b/test/integration/api/v1/owner_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class OwnerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @other_user = create(:user)
+    cookies[:remember_token] = @user.remember_token
+
+    @rubygem = create(:rubygem, number: "1.0.0")
+    create(:ownership, user: @user, rubygem: @rubygem)
+  end
+
+  test "adding an owner" do
+    post api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
+    assert_response :success
+
+    @ownership = @other_user.ownerships.find_by(rubygem_id: @rubygem.id)
+    get confirm_rubygem_owners_url(@rubygem, token: @ownership.token.html_safe)
+
+    get rubygem_path(@rubygem)
+    assert page.has_selector?("a[alt='#{@user.handle}']")
+    assert page.has_selector?("a[alt='#{@other_user.handle}']")
+  end
+
+  test "removing an owner" do
+    create(:ownership, user: @other_user, rubygem: @rubygem)
+    delete api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
+
+    get rubygem_path(@rubygem)
+    assert page.has_selector?("a[alt='#{@user.handle}']")
+    refute page.has_selector?("a[alt='#{@other_user.handle}']")
+  end
+
+  test "transferring ownership" do
+    create(:ownership, user: @other_user, rubygem: @rubygem)
+
+    delete api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @user.email },
+      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
+
+    get rubygem_path(@rubygem)
+    refute page.has_selector?("a[alt='#{@user.handle}']")
+    assert page.has_selector?("a[alt='#{@other_user.handle}']")
+  end
+
+  test "adding ownership without permission" do
+    post api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @other_user.api_key }
+    assert_response :unauthorized
+
+    delete api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @other_user.api_key }
+    assert_response :unauthorized
+  end
+end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -86,7 +86,8 @@ class GemsSystemTest < SystemTest
     @user.enable_mfa!("some-seed", "ui_and_api")
     user_without_mfa = create(:user, mfa_level: "disabled")
 
-    @rubygem.owners << [@user, user_without_mfa]
+    create(:ownership, rubygem: @rubygem, user: @user)
+    create(:ownership, rubygem: @rubygem, user: user_without_mfa)
 
     visit rubygem_path(@rubygem, as: @user.id)
 
@@ -98,7 +99,8 @@ class GemsSystemTest < SystemTest
     @user.enable_mfa!("some-seed", "ui_and_api")
     user_with_mfa = create(:user, mfa_level: "ui_only")
 
-    @rubygem.owners << [@user, user_with_mfa]
+    create(:ownership, rubygem: @rubygem, user: @user)
+    create(:ownership, rubygem: @rubygem, user: user_with_mfa)
 
     visit rubygem_path(@rubygem, as: @user.id)
 
@@ -110,7 +112,8 @@ class GemsSystemTest < SystemTest
     @user.enable_mfa!("some-seed", "ui_and_api")
     user_without_mfa = create(:user, mfa_level: "disabled")
 
-    @rubygem.owners << [@user, user_without_mfa]
+    create(:ownership, rubygem: @rubygem, user: @user)
+    create(:ownership, rubygem: @rubygem, user: user_without_mfa)
 
     visit rubygem_path(@rubygem)
 

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -18,12 +18,17 @@ class NotificationSettingsTest < SystemTest
     notifier_form_selector = "form[action='/notifier']"
 
     within_element notifier_form_selector do
-      assert_checked_field notifier_on_radio(ownership1)
-      assert_unchecked_field notifier_off_radio(ownership1)
-      assert_checked_field notifier_on_radio(ownership2)
-      assert_unchecked_field notifier_off_radio(ownership2)
+      assert_checked_field notifier_on_radio(ownership1, "push")
+      assert_unchecked_field notifier_off_radio(ownership1, "push")
+      assert_checked_field notifier_on_radio(ownership2, "push")
+      assert_unchecked_field notifier_off_radio(ownership2, "push")
+      assert_checked_field notifier_on_radio(ownership1, "owner")
+      assert_unchecked_field notifier_off_radio(ownership1, "owner")
+      assert_checked_field notifier_on_radio(ownership2, "owner")
+      assert_unchecked_field notifier_off_radio(ownership2, "owner")
 
-      choose notifier_off_radio(ownership1)
+      choose notifier_off_radio(ownership1, "push")
+      choose notifier_off_radio(ownership2, "owner")
 
       click_button I18n.t("notifiers.show.update")
     end
@@ -37,10 +42,14 @@ class NotificationSettingsTest < SystemTest
     assert_selector "#flash_notice", text: I18n.t("notifiers.update.success")
 
     within_element notifier_form_selector do
-      assert_unchecked_field notifier_on_radio(ownership1)
-      assert_checked_field notifier_off_radio(ownership1)
-      assert_checked_field notifier_on_radio(ownership2)
-      assert_unchecked_field notifier_off_radio(ownership2)
+      assert_unchecked_field notifier_on_radio(ownership1, "push")
+      assert_checked_field notifier_off_radio(ownership1, "push")
+      assert_checked_field notifier_on_radio(ownership2, "push")
+      assert_unchecked_field notifier_off_radio(ownership2, "push")
+      assert_checked_field notifier_on_radio(ownership1, "owner")
+      assert_unchecked_field notifier_off_radio(ownership1, "owner")
+      assert_unchecked_field notifier_on_radio(ownership2, "owner")
+      assert_checked_field notifier_off_radio(ownership2, "owner")
     end
   end
 
@@ -66,11 +75,11 @@ class NotificationSettingsTest < SystemTest
     assert_no_text "yanked-gem"
   end
 
-  def notifier_on_radio(ownership)
-    "ownerships_#{ownership.id}_on"
+  def notifier_on_radio(ownership, type)
+    "ownerships_#{ownership.id}_#{type}_on"
   end
 
-  def notifier_off_radio(ownership)
-    "ownerships_#{ownership.id}_off"
+  def notifier_off_radio(ownership, type)
+    "ownerships_#{ownership.id}_#{type}_off"
   end
 end

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -7,7 +7,7 @@ class OwnerTest < ActionDispatch::IntegrationTest
     cookies[:remember_token] = @user.remember_token
 
     @rubygem = create(:rubygem, number: "1.0.0")
-    @ownership = create(:ownership, user: @user, rubygem: @rubygem)
+    create(:ownership, user: @user, rubygem: @rubygem)
   end
 
   test "adding an owner" do
@@ -15,6 +15,9 @@ class OwnerTest < ActionDispatch::IntegrationTest
       params: { email: @other_user.email },
       headers: { "HTTP_AUTHORIZATION" => @user.api_key }
     assert_response :success
+
+    @ownership = @other_user.ownerships.find_by(rubygem_id: @rubygem.id)
+    visit confirm_rubygem_owners_url(@rubygem, token: @ownership.token.html_safe)
 
     get rubygem_path(@rubygem)
     assert page.has_selector?("a[alt='#{@user.handle}']")

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -1,61 +1,144 @@
 require "test_helper"
 
-class OwnerTest < ActionDispatch::IntegrationTest
+class OwnerTest < SystemTest
+  include RubygemsHelper
+
   setup do
     @user = create(:user)
     @other_user = create(:user)
-    cookies[:remember_token] = @user.remember_token
-
     @rubygem = create(:rubygem, number: "1.0.0")
-    create(:ownership, user: @user, rubygem: @rubygem)
+    @ownership = create(:ownership, user: @user, rubygem: @rubygem)
+
+    sign_in_as(@user)
   end
 
-  test "adding an owner" do
-    post api_v1_rubygem_owners_path(@rubygem),
-      params: { email: @other_user.email },
-      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
-    assert_response :success
+  test "adding owner via UI with email" do
+    visit_ownerships_page
 
-    @ownership = @other_user.ownerships.find_by(rubygem_id: @rubygem.id)
-    visit confirm_rubygem_owners_url(@rubygem, token: @ownership.token.html_safe)
+    fill_in "Name of user", with: @other_user.email
+    click_button "Add Owner"
+    within(".owners__table") do
+      assert page.has_content? @other_user.handle
+    end
 
-    get rubygem_path(@rubygem)
-    assert page.has_selector?("a[alt='#{@user.handle}']")
-    assert page.has_selector?("a[alt='#{@other_user.handle}']")
+    assert_cell(@other_user, "Confirmed", "✗")
+    assert_cell(@other_user, "Added By", @user.handle)
+    assert_cell(@other_user, "Added On", nice_date_for(@ownership.confirmed_at))
   end
 
-  test "removing an owner" do
+  test "adding owner via UI with handle" do
+    visit_ownerships_page
+
+    fill_in "Name of user", with: @other_user.handle
+    click_button "Add Owner"
+
+    assert_cell(@other_user, "Confirmed", "✗")
+    assert_cell(@other_user, "Added By", @user.handle)
+  end
+
+  test "owners data is correctly represented" do
+    @other_user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    create(:ownership, :unconfirmed, user: @other_user, rubygem: @rubygem)
+
+    visit_ownerships_page
+
+    assert_cell(@other_user, "Confirmed", "✗")
+    assert_cell(@other_user, "MFA", "✔")
+
+    assert_cell(@user, "Confirmed", "✔")
+    assert_cell(@other_user, "MFA", "✗")
+  end
+
+  test "removing owner" do
     create(:ownership, user: @other_user, rubygem: @rubygem)
-    delete api_v1_rubygem_owners_path(@rubygem),
-      params: { email: @other_user.email },
-      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
 
-    get rubygem_path(@rubygem)
-    assert page.has_selector?("a[alt='#{@user.handle}']")
-    refute page.has_selector?("a[alt='#{@other_user.handle}']")
+    visit_ownerships_page
+
+    within(".owners__table") do
+      within(find("tr", text: @other_user.handle)) do
+        click_button "Remove"
+      end
+    end
+
+    refute page.has_selector?("a[href='#{profile_path(@other_user)}']")
   end
 
-  test "transferring ownership" do
-    create(:ownership, user: @other_user, rubygem: @rubygem)
+  test "removing last owner shows error message" do
+    visit_ownerships_page
 
-    delete api_v1_rubygem_owners_path(@rubygem),
-      params: { email: @user.email },
-      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
+    within(".owners__table") do
+      within(find("tr", text: @user.handle)) do
+        click_button "Remove"
+      end
+    end
 
-    get rubygem_path(@rubygem)
-    refute page.has_selector?("a[alt='#{@user.handle}']")
-    assert page.has_selector?("a[alt='#{@other_user.handle}']")
+    assert page.has_selector?("a[href='#{profile_path(@user)}']")
+    assert page.has_selector? "#flash_alert", text: "Owner cannot be removed!"
   end
 
-  test "adding ownership without permission" do
-    post api_v1_rubygem_owners_path(@rubygem),
-      params: { email: @other_user.email },
-      headers: { "HTTP_AUTHORIZATION" => @other_user.api_key }
-    assert_response :unauthorized
+  test "clicking on confirmation link confirms the account" do
+    @unconfirmed_ownership = create(:ownership, :unconfirmed, rubygem: @rubygem)
+    confirmation_link = confirm_rubygem_owners_url(@rubygem, token: @unconfirmed_ownership.token)
+    visit confirmation_link
 
-    delete api_v1_rubygem_owners_path(@rubygem),
-      params: { email: @other_user.email },
-      headers: { "HTTP_AUTHORIZATION" => @other_user.api_key }
-    assert_response :unauthorized
+    assert_equal page.current_path, rubygem_path(@rubygem)
+    assert page.has_selector? "#flash_notice", text: "You are added as an owner to #{@rubygem.name} gem!"
+  end
+
+  test "clicking on incorrect link shows error" do
+    confirmation_link = confirm_rubygem_owners_url(@rubygem, token: SecureRandom.hex(20).encode("UTF-8"))
+    visit confirmation_link
+
+    assert_equal page.current_path, root_path
+    assert page.has_selector? "#flash_alert", text: "The confirmation token has expired. Please try resending the token"
+  end
+
+
+  test "shows ownership link when is owner" do
+    visit rubygem_path(@rubygem)
+    assert page.has_selector?("a[href='#{rubygem_owners_path(@rubygem)}']")
+  end
+
+  test "hides ownership link when not owner" do
+    page.find("a[href='/sign_out']").click
+    sign_in_as(@other_user)
+    visit rubygem_path(@rubygem)
+    refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem)}']")
+  end
+
+  test "hides ownership link when not signed in" do
+    page.find("a[href='/sign_out']").click
+    visit rubygem_path(@rubygem)
+    refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem)}']")
+  end
+
+  test "shows resend confirmation link when unconfirmed" do
+    page.find("a[href='/sign_out']").click
+    create(:ownership, :unconfirmed, user: @other_user, rubygem: @rubygem)
+    sign_in_as(@other_user)
+    visit rubygem_path(@rubygem)
+    refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem)}']")
+    assert page.has_selector?("a[href='#{resend_confirmation_rubygem_owners_url(@rubygem)}']")
+  end
+
+  def assert_cell(user, column, expected)
+    within(".owners__table") do
+      assert page.has_selector?("a[href='#{profile_path(user)}']")
+      within(find("tr", text: user.handle)) do
+        find("td[data-title='#{column}']").has_content? expected
+      end
+    end
+  end
+
+  def visit_ownerships_page
+    visit rubygem_path(@rubygem)
+    click_link "Ownership"
+  end
+
+  def sign_in_as(user)
+    visit sign_in_path
+    fill_in "Email or Username", with: user.email
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
   end
 end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -25,7 +25,7 @@ class MailerPreview < ActionMailer::Preview
   end
 
   def gem_pushed
-    ownership = Ownership.where.not(user: nil).where(notifier: true).last
+    ownership = Ownership.where.not(user: nil).where(push_notifier: true).last
     Mailer.gem_pushed(ownership.user_id, ownership.rubygem.versions.last.id, ownership.user_id)
   end
 

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -42,4 +42,15 @@ class MailerPreview < ActionMailer::Preview
     user = User.last
     Mailer.reset_api_key(user)
   end
+
+  def ownership_confirmation
+    Mailer.ownership_confirmation(Ownership.last.id)
+  end
+
+  def owners_update
+    gem = Rubygem.last
+    owner = gem.owners.first
+    user = User.last
+    Mailer.owners_update(owner.id, user.id, "added", gem.id)
+  end
 end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -47,10 +47,17 @@ class MailerPreview < ActionMailer::Preview
     Mailer.ownership_confirmation(Ownership.last.id)
   end
 
-  def owners_update
-    gem = Rubygem.last
+  def owner_removed
+    gem = Rubygem.order(updated_at: :desc).last
     owner = gem.owners.first
     user = User.last
-    Mailer.owners_update(owner.id, user.id, "added", gem.id)
+    Mailer.owner_removed(owner.id, user.id, gem.id)
+  end
+
+  def owner_added
+    gem = Rubygem.order(updated_at: :desc).last
+    owner = gem.owners.first
+    user = User.last
+    Mailer.owner_added(owner.id, user.id, gem.id)
   end
 end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -234,7 +234,7 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "be true if owned by the user" do
-        @rubygem.ownerships.create(user: @user)
+        create(:ownership, rubygem: @rubygem, user: @user)
         assert @cutter.authorize
       end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -327,7 +327,7 @@ class RubygemTest < ActiveSupport::TestCase
 
       should "not be able to assign ownership when owners exist" do
         @new_user = create(:user)
-        @rubygem.ownerships.create(user: @new_user)
+        create(:ownership, rubygem: @rubygem, user: @new_user)
         @rubygem.create_ownership(@user)
         assert_equal @rubygem.reload.owners, [@new_user]
       end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -405,7 +405,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "user has co-owner of gem" do
       setup do
-        @rubygem.ownerships.create(user: create(:user))
+        create(:ownership, rubygem: @rubygem, user: create(:user))
       end
 
       should "not record deletion" do


### PR DESCRIPTION
@sonalkr132 Please have a look. 

Thoughts behind this design:
- More columns were not looking clean. And made difficult to add more data.
- Wanted to show profile pic as that's easier to understand
- This can show email as well as handle in case of similar usernames
- This design has more icons => more intuitive.
- Isn't covering important data for the page under hover.
- To fit in a wider table as earlier, had changed the layout which was followed in base.css which is used in show#rubygems because that much padding wasn't working out. This design is following columns arrangement of base.css only so consistent design and lesser CSS is needed.

Ownership applications will also be a similar data rich page. This design can be reused there too.